### PR TITLE
Revert "Add ca_truster job to templates"

### DIFF
--- a/manifest-templates/cf-lamb.yml
+++ b/manifest-templates/cf-lamb.yml
@@ -9,15 +9,11 @@ lamb_meta:
     release: (( lamb_meta.release.name ))
   - name: metron_agent
     release: (( lamb_meta.release.name ))
-  - name: ca_truster
-    release: (( lamb_meta.release.name ))
 
   loggregator_trafficcontroller_templates:
   - name: loggregator_trafficcontroller
     release: (( lamb_meta.release.name ))
   - name: metron_agent
-    release: (( lamb_meta.release.name ))
-  - name: ca_truster
     release: (( lamb_meta.release.name ))
 
 jobs:

--- a/manifest-templates/lamb-properties.rb
+++ b/manifest-templates/lamb-properties.rb
@@ -51,8 +51,6 @@ class LambProperties
       release: cf
     - name: metron_agent
       release: cf
-    - name: ca_truster
-      release: cf
     EOF
     result.chomp
   end
@@ -62,8 +60,6 @@ class LambProperties
     - name: loggregator_trafficcontroller
       release: cf
     - name: metron_agent
-      release: cf
-    - name: ca_truster
       release: cf
     EOF
     result.chomp


### PR DESCRIPTION
Hi LAMB,

We are reverting the ca_truster job from cf-release and as a result we need to remove the ca_truster configuration from the manifest templates. See https://www.pivotaltracker.com/story/show/90139570 for more information.

Thanks,

@jfmyers9 && @sergueif, CF Runtime Team