### PR TITLE
Reuse store adapter for Doppler

### DIFF
--- a/src/doppler/doppler_test.go
+++ b/src/doppler/doppler_test.go
@@ -22,7 +22,8 @@ var _ = Describe("Doppler Server", func() {
 	var dopplerInstance *doppler.Doppler
 
 	BeforeEach(func() {
-		dopplerInstance = doppler.New("127.0.0.1", dopplerConfig, loggertesthelper.Logger(), "dropsondeOrigin")
+		storeAdapter := doppler.NewStoreAdapter(dopplerConfig.EtcdUrls, dopplerConfig.EtcdMaxConcurrentRequests)
+		dopplerInstance = doppler.New("127.0.0.1", dopplerConfig, loggertesthelper.Logger(), storeAdapter, "dropsondeOrigin")
 		go dopplerInstance.Start()
 		time.Sleep(10 * time.Millisecond)
 	})

--- a/src/doppler/main_integration_test.go
+++ b/src/doppler/main_integration_test.go
@@ -40,6 +40,8 @@ var _ = Describe("Etcd Integration tests", func() {
 			Zone:                      "z1",
 			ContainerMetricTTLSeconds: 120,
 		}
+
+		main.SetStoreAdapter(main.NewStoreAdapter(conf.EtcdUrls, conf.EtcdMaxConcurrentRequests))
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
There is no need to create store adapter in both [main.go](https://github.com/cloudfoundry/loggregator/blob/develop/src/doppler/main.go#L166) and [doppler.go](https://github.com/cloudfoundry/loggregator/blob/develop/src/doppler/doppler.go#L57), so pass the adapter to Doppler.