### PR TITLE
Add consul agent to the traffic_controller

### DIFF
--- a/bosh/jobs/loggregator_trafficcontroller/spec
+++ b/bosh/jobs/loggregator_trafficcontroller/spec
@@ -3,11 +3,14 @@ name: loggregator_trafficcontroller
 templates:
   loggregator_trafficcontroller_ctl.erb: bin/loggregator_trafficcontroller_ctl
   loggregator_trafficcontroller.json.erb: config/loggregator_trafficcontroller.json
+  dns_health_check.erb: bin/dns_health_check
 
 packages:
 - common
 - loggregator_trafficcontroller
 properties:
+  networks.apps:
+    description: "Network information for the Traffic Controller"
   traffic_controller.zone:
     description: Zone of the loggregator_trafficcontroller
   traffic_controller.host:

--- a/bosh/jobs/loggregator_trafficcontroller/templates/dns_health_check.erb
+++ b/bosh/jobs/loggregator_trafficcontroller/templates/dns_health_check.erb
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+<% my_ip = spec.networks.send(properties.networks.apps).ip %>
+
+nc -z <%= my_ip %> <%= p("traffic_controller.outgoing_port") %>
+
+# http://www.consul.io/docs/agent/checks.html
+if [ $? -ne 0 ]; then
+  exit 2 # Exit higher than 1 to ensure service is registered as 'critical'
+fi

--- a/manifest-templates/cf-lamb.yml
+++ b/manifest-templates/cf-lamb.yml
@@ -18,6 +18,8 @@ lamb_meta:
     release: (( lamb_meta.release.name ))
   - name: metron_agent
     release: (( lamb_meta.release.name ))
+  - name: consul_agent
+    release: (( lamb_meta.release.name ))
 
 jobs:
 - name: loggregator_z1
@@ -40,6 +42,10 @@ jobs:
       zone: z1
     metron_agent:
       zone: z1
+    consul:
+      agent:
+        services:
+          - loggregator_trafficcontroller
 
 - name: loggregator_trafficcontroller_z2
   properties:
@@ -47,6 +53,10 @@ jobs:
       zone: z2
     metron_agent:
       zone: z2
+    consul:
+      agent:
+        services:
+          - loggregator_trafficcontroller
 
 properties:
   <<: (( merge ))

--- a/manifest-templates/lamb-properties.rb
+++ b/manifest-templates/lamb-properties.rb
@@ -29,6 +29,10 @@ class LambProperties
       zone: z1
     traffic_controller:
       zone: z1
+    consul:
+      agent:
+        services:
+          - loggregator_trafficcontroller
     EOF
     result.chomp
   end
@@ -39,6 +43,10 @@ class LambProperties
       zone: z2
     traffic_controller:
       zone: z2
+    consul:
+      agent:
+        services:
+          - loggregator_trafficcontroller
     EOF
     result.chomp
   end
@@ -60,6 +68,8 @@ class LambProperties
     - name: loggregator_trafficcontroller
       release: cf
     - name: metron_agent
+      release: cf
+    - name: consul_agent
       release: cf
     EOF
     result.chomp


### PR DESCRIPTION
Diego needs to locate the Traffic Controller using consul so that the TPS can retrieve app metrics for apps running on Diego. By default consul is not deployed in cf-release, however co-locating the consul_agent on the VM will not affect the operation of the Traffic Controller (cloud_controller already does this.)

Thanks,

@jfmyers9 && @atulkc