### PR TITLE
Fix for https://github.com/cloudfoundry/cf-release/issues/690

### DIFF
--- a/manifest-templates/cf-lamb.yml
+++ b/manifest-templates/cf-lamb.yml
@@ -26,6 +26,7 @@ jobs:
       zone: z1
     metron_agent:
       zone: z1
+      deployment: (( meta.environment ))
 
 - name: loggregator_z2
   properties:
@@ -33,6 +34,7 @@ jobs:
       zone: z2
     metron_agent:
       zone: z2
+      deployment: (( meta.environment ))
 
 - name: doppler_z1
   properties:
@@ -40,6 +42,7 @@ jobs:
       zone: z1
     metron_agent:
       zone: z1
+      deployment: (( meta.environment ))
 
 - name: doppler_z2
   properties:
@@ -47,6 +50,7 @@ jobs:
       zone: z2
     metron_agent:
       zone: z2
+      deployment: (( meta.environment ))
 
 - name: loggregator_trafficcontroller_z1
   properties:
@@ -54,6 +58,7 @@ jobs:
       zone: z1
     metron_agent:
       zone: z1
+      deployment: (( meta.environment ))
 
 - name: loggregator_trafficcontroller_z2
   properties:
@@ -61,6 +66,7 @@ jobs:
       zone: z2
     metron_agent:
       zone: z2
+      deployment: (( meta.environment ))
 
 properties:
   <<: (( merge ))


### PR DESCRIPTION
Explictly specify metron_agent.deployment as commit 4cf24609de594cc8944c50a6d5ec5db9a1e7c701 seems not effectively defining the property for jobs (using spiff 1.0.6)