### PR TITLE
Log the slow sink url when buffer overflows

### DIFF
--- a/src/doppler/sinks/sink.go
+++ b/src/doppler/sinks/sink.go
@@ -2,6 +2,7 @@ package sinks
 
 import (
 	"doppler/truncatingbuffer"
+
 	"github.com/cloudfoundry/gosteno"
 	"github.com/cloudfoundry/sonde-go/events"
 )
@@ -18,8 +19,8 @@ type Metric struct {
 	Value int64
 }
 
-func RunTruncatingBuffer(inputChan <-chan *events.Envelope, bufferSize uint, logger *gosteno.Logger, dropsondeOrigin string) *truncatingbuffer.TruncatingBuffer {
-	b := truncatingbuffer.NewTruncatingBuffer(inputChan, bufferSize, logger, dropsondeOrigin)
+func RunTruncatingBuffer(inputChan <-chan *events.Envelope, bufferSize uint, logger *gosteno.Logger, dropsondeOrigin, sinkIdentifier string) *truncatingbuffer.TruncatingBuffer {
+	b := truncatingbuffer.NewTruncatingBuffer(inputChan, bufferSize, logger, dropsondeOrigin, sinkIdentifier)
 	go b.Run()
 	return b
 }

--- a/src/doppler/sinks/syslog/syslog_sink.go
+++ b/src/doppler/sinks/syslog/syslog_sink.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"doppler/sinks"
+
 	"github.com/cloudfoundry/gosteno"
 	"github.com/cloudfoundry/sonde-go/events"
 )
@@ -70,11 +71,12 @@ func (s *SyslogSink) Run(inputChan <-chan *events.Envelope) {
 		}
 	}()
 
-	buffer := sinks.RunTruncatingBuffer(filteredChan, s.messageDrainBufferSize, s.logger, s.dropsondeOrigin)
+	buffer := sinks.RunTruncatingBuffer(filteredChan, s.messageDrainBufferSize, s.logger, s.dropsondeOrigin, s.Identifier())
 	timer := time.NewTimer(backoffStrategy(numberOfTries))
 	connected := false
 	defer timer.Stop()
 	defer s.syslogWriter.Close()
+
 	s.logger.Debugf("Syslog Sink %s: Starting loop. Current backoff: %v", s.drainUrl, backoffStrategy(numberOfTries))
 	for {
 		if !connected {

--- a/src/doppler/sinks/websocket/websocket_sink.go
+++ b/src/doppler/sinks/websocket/websocket_sink.go
@@ -52,7 +52,7 @@ func (sink *WebsocketSink) ShouldReceiveErrors() bool {
 func (sink *WebsocketSink) Run(inputChan <-chan *events.Envelope) {
 	sink.logger.Debugf("Websocket Sink %s: Running for streamId [%s]", sink.clientAddress, sink.streamId)
 
-	buffer := sinks.RunTruncatingBuffer(inputChan, sink.messageDrainBufferSize, sink.logger, sink.dropsondeOrigin)
+	buffer := sinks.RunTruncatingBuffer(inputChan, sink.messageDrainBufferSize, sink.logger, sink.dropsondeOrigin, sink.Identifier())
 	for {
 		sink.logger.Debugf("Websocket Sink %s: Waiting for activity", sink.clientAddress)
 		messageEnvelope, ok := <-buffer.GetOutputChannel()

--- a/src/doppler/truncatingbuffer/truncating_buffer_test.go
+++ b/src/doppler/truncatingbuffer/truncating_buffer_test.go
@@ -23,13 +23,13 @@ var _ = Describe("Truncating Buffer", func() {
 	It("panics if buffer size is less than 3", func() {
 		inMessageChan := make(chan *events.Envelope)
 		Expect(func() {
-			truncatingbuffer.NewTruncatingBuffer(inMessageChan, 2, loggertesthelper.Logger(), "dropsonde-origin")
+			truncatingbuffer.NewTruncatingBuffer(inMessageChan, 2, loggertesthelper.Logger(), "dropsonde-origin", "test-sync-name")
 		}).To(Panic())
 	})
 
 	It("works like a channel", func() {
 		inMessageChan := make(chan *events.Envelope)
-		buffer := truncatingbuffer.NewTruncatingBuffer(inMessageChan, 3, loggertesthelper.Logger(), "dropsonde-origin")
+		buffer := truncatingbuffer.NewTruncatingBuffer(inMessageChan, 3, loggertesthelper.Logger(), "dropsonde-origin", "test-sink-name")
 		go buffer.Run()
 
 		sendLogMessages("message 1", inMessageChan)
@@ -46,7 +46,7 @@ var _ = Describe("Truncating Buffer", func() {
 
 	It("works like a truncating channel", func() {
 		inMessageChan := make(chan *events.Envelope)
-		buffer := truncatingbuffer.NewTruncatingBuffer(inMessageChan, 3, loggertesthelper.Logger(), "dropsonde-origin")
+		buffer := truncatingbuffer.NewTruncatingBuffer(inMessageChan, 3, loggertesthelper.Logger(), "dropsonde-origin", "test-sink-name")
 		go buffer.Run()
 
 		sendLogMessages("message 1", inMessageChan)
@@ -57,7 +57,7 @@ var _ = Describe("Truncating Buffer", func() {
 		time.Sleep(5 * time.Millisecond)
 
 		logMessageNotification := <-buffer.GetOutputChannel()
-		Expect(logMessageNotification.GetLogMessage().GetMessage()).To(ContainSubstring("Log message output too high. We've dropped 3 messages"))
+		Expect(logMessageNotification.GetLogMessage().GetMessage()).To(ContainSubstring("Log message output too high. We've dropped 3 messages to test-sink-name."))
 
 		counterEventNotification := <-buffer.GetOutputChannel()
 		Expect(counterEventNotification.GetEventType()).To(Equal(events.Envelope_CounterEvent))
@@ -87,7 +87,7 @@ var _ = Describe("Truncating Buffer", func() {
 
 	It("keeps track of dropped messages", func(done Done) {
 		inMessageChan := make(chan *events.Envelope)
-		buffer := truncatingbuffer.NewTruncatingBuffer(inMessageChan, 3, loggertesthelper.Logger(), "dropsonde-origin")
+		buffer := truncatingbuffer.NewTruncatingBuffer(inMessageChan, 3, loggertesthelper.Logger(), "dropsonde-origin", "test-sync-name")
 		Expect(buffer.GetDroppedMessageCount()).To(Equal(int64(0)))
 		go buffer.Run()
 
@@ -110,7 +110,7 @@ var _ = Describe("Truncating Buffer", func() {
 		fakeEventEmitter.Reset()
 
 		inMessageChan := make(chan *events.Envelope)
-		buffer := truncatingbuffer.NewTruncatingBuffer(inMessageChan, 3, loggertesthelper.Logger(), "dropsonde-origin")
+		buffer := truncatingbuffer.NewTruncatingBuffer(inMessageChan, 3, loggertesthelper.Logger(), "dropsonde-origin", "test-sync-name")
 		Expect(buffer.GetDroppedMessageCount()).To(Equal(int64(0)))
 		go buffer.Run()
 


### PR DESCRIPTION
If an application is configured to use more than one log sink, it's difficult for the operator and user to determine which one is not keeping up. Including the sink target should make it easier to figure out.