### PR TITLE
Set https syslog writer max idle connections to 1

### DIFF
--- a/src/doppler/sinks/syslogwriter/https_writer.go
+++ b/src/doppler/sinks/syslogwriter/https_writer.go
@@ -21,7 +21,7 @@ type httpsWriter struct {
 	appId     string
 	outputUrl *url.URL
 
-	mu sync.Mutex // guards conn
+	mu sync.Mutex // guards lastError
 
 	tlsConfig *tls.Config
 	client    *http.Client
@@ -38,6 +38,7 @@ func NewHttpsWriter(outputUrl *url.URL, appId string, skipCertVerify bool, diale
 	}
 	tlsConfig := &tls.Config{InsecureSkipVerify: skipCertVerify}
 	tr := &http.Transport{
+		MaxIdleConnsPerHost: 1,
 		TLSClientConfig:     tlsConfig,
 		TLSHandshakeTimeout: dialer.Timeout * 2,
 		Dial: func(network, addr string) (net.Conn, error) {
@@ -54,6 +55,8 @@ func NewHttpsWriter(outputUrl *url.URL, appId string, skipCertVerify bool, diale
 }
 
 func (w *httpsWriter) Connect() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	if w.lastError != nil {
 		err := w.lastError
 		w.lastError = nil
@@ -64,9 +67,11 @@ func (w *httpsWriter) Connect() error {
 
 func (w *httpsWriter) Write(p int, b []byte, source string, sourceId string, timestamp int64) (int, error) {
 	syslogMsg := createMessage(p, w.appId, source, sourceId, b, timestamp)
-	var bytesWritten int
-	bytesWritten, w.lastError = w.writeHttp(syslogMsg)
-	return bytesWritten, w.lastError
+	bytesWritten, err := w.writeHttp(syslogMsg)
+	w.mu.Lock()
+	w.lastError = err
+	w.mu.Unlock()
+	return bytesWritten, err
 }
 
 func (w *httpsWriter) Close() error {


### PR DESCRIPTION
Since each https writer gets its own transport, the idle connection pools aren't shared. By setting the size to 1, we can ensure we don't get more than one connection.