### PR TITLE
Allow configurable dialer timeout

### DIFF
--- a/bosh/jobs/doppler/spec
+++ b/bosh/jobs/doppler/spec
@@ -49,6 +49,9 @@ properties:
   doppler.sink_inactivity_timeout_seconds:
     description: "Interval before removing a sink due to inactivity"
     default: 3600
+  doppler.sink_dial_timeout_seconds:
+    description: "Dial timeout for sinks"
+    default: 1
   doppler_endpoint.shared_secret:
     description: "Shared secret used to verify cryptographically signed doppler messages"
   doppler.message_drain_buffer_size:

--- a/bosh/jobs/doppler/templates/doppler.json.erb
+++ b/bosh/jobs/doppler/templates/doppler.json.erb
@@ -15,6 +15,7 @@
   "SharedSecret": "<%= p("doppler_endpoint.shared_secret") %>",
   "ContainerMetricTTLSeconds": <%= p("doppler.container_metric_ttl_seconds") %>,
   "SinkInactivityTimeoutSeconds": <%= p("doppler.sink_inactivity_timeout_seconds") %>,
+  "SinkDialTimeoutSeconds": <%= p("doppler.sink_dial_timeout_seconds") %>,
   "UnmarshallerCount": <%= p("doppler.unmarshaller_count") %>,
 
   "MetronAddress": "<%= p("metron_endpoint.host") %>:<%= p("metron_endpoint.dropsonde_port") %>",

--- a/src/doppler/config/config.go
+++ b/src/doppler/config/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	UnmarshallerCount             int
 	MetronAddress                 string
 	MonitorIntervalSeconds        uint
+	SinkDialTimeoutSeconds        int
 }
 
 func (c *Config) Validate(logger *gosteno.Logger) (err error) {

--- a/src/doppler/doppler.go
+++ b/src/doppler/doppler.go
@@ -12,6 +12,7 @@ import (
 	"doppler/sinkserver/websocketserver"
 
 	"common/monitor"
+
 	"github.com/cloudfoundry/dropsonde/dropsonde_unmarshaller"
 	"github.com/cloudfoundry/dropsonde/signature"
 	"github.com/cloudfoundry/gosteno"
@@ -49,7 +50,7 @@ type Doppler struct {
 	wg                                       sync.WaitGroup
 }
 
-func New(host string, config *config.Config, logger *gosteno.Logger, storeAdapter storeadapter.StoreAdapter, messageDrainBufferSize uint, dropsondeOrigin string) *Doppler {
+func New(host string, config *config.Config, logger *gosteno.Logger, storeAdapter storeadapter.StoreAdapter, messageDrainBufferSize uint, dropsondeOrigin string, dialTimeout time.Duration) *Doppler {
 	cfcomponent.Logger = logger
 	keepAliveInterval := 30 * time.Second
 
@@ -65,7 +66,7 @@ func New(host string, config *config.Config, logger *gosteno.Logger, storeAdapte
 	blacklist := blacklist.New(config.BlackListIps)
 	metricTTL := time.Duration(config.ContainerMetricTTLSeconds) * time.Second
 	sinkTimeout := time.Duration(config.SinkInactivityTimeoutSeconds) * time.Second
-	sinkManager := sinkmanager.New(config.MaxRetainedLogMessages, config.SkipCertVerify, blacklist, logger, messageDrainBufferSize, dropsondeOrigin, sinkTimeout, metricTTL)
+	sinkManager := sinkmanager.New(config.MaxRetainedLogMessages, config.SkipCertVerify, blacklist, logger, messageDrainBufferSize, dropsondeOrigin, sinkTimeout, metricTTL, dialTimeout)
 
 	return &Doppler{
 		Logger:                          logger,

--- a/src/doppler/main.go
+++ b/src/doppler/main.go
@@ -107,7 +107,7 @@ func main() {
 	}
 
 	storeAdapter := NewStoreAdapter(conf.EtcdUrls, conf.EtcdMaxConcurrentRequests)
-	doppler := New(localIp, conf, logger, storeAdapter, conf.MessageDrainBufferSize, "doppler")
+	doppler := New(localIp, conf, logger, storeAdapter, conf.MessageDrainBufferSize, "doppler", time.Duration(conf.SinkDialTimeoutSeconds)*time.Second)
 
 	if err != nil {
 		panic(err)
@@ -143,6 +143,10 @@ func ParseConfig(logLevel *bool, configFile, logFilePath *string) (*config.Confi
 
 	if config.MonitorIntervalSeconds == 0 {
 		config.MonitorIntervalSeconds = 60
+	}
+
+	if config.SinkDialTimeoutSeconds == 0 {
+		config.SinkDialTimeoutSeconds = 1
 	}
 
 	logger := cfcomponent.NewLogger(*logLevel, *logFilePath, "doppler", config.Config)

--- a/src/doppler/sinks/syslogwriter/https_writer_test.go
+++ b/src/doppler/sinks/syslogwriter/https_writer_test.go
@@ -2,6 +2,7 @@ package syslogwriter_test
 
 import (
 	"doppler/sinks/syslogwriter"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -12,17 +13,19 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+const standardErrorPriority = 14
+
 var _ = Describe("HttpsWriter", func() {
 
-	Context("With an HTTPS Connection", func() {
-
+	Context("With an HTTPS Sink", func() {
 		var server *httptest.Server
 		var requestChan chan []byte
-		standardErrorPriority := 14
+		var dialer *net.Dialer
 
 		BeforeEach(func() {
 			requestChan = make(chan []byte, 1)
 			server = ServeHTTP(requestChan)
+			dialer = &net.Dialer{Timeout: 1 * time.Second}
 		})
 
 		AfterEach(func() {
@@ -33,7 +36,7 @@ var _ = Describe("HttpsWriter", func() {
 		It("HTTP POSTs each log message to the HTTPS syslog endpoint", func() {
 			outputUrl, _ := url.Parse(server.URL + "/234-bxg-234/")
 
-			w, _ := syslogwriter.NewHttpsWriter(outputUrl, "appId", true)
+			w, _ := syslogwriter.NewHttpsWriter(outputUrl, "appId", true, dialer)
 			err := w.Connect()
 			Expect(err).ToNot(HaveOccurred())
 
@@ -50,7 +53,7 @@ var _ = Describe("HttpsWriter", func() {
 		It("returns an error when unable to HTTP POST the log message", func() {
 			outputUrl, _ := url.Parse("https://")
 
-			w, _ := syslogwriter.NewHttpsWriter(outputUrl, "appId", true)
+			w, _ := syslogwriter.NewHttpsWriter(outputUrl, "appId", true, dialer)
 
 			_, err := w.Write(standardErrorPriority, []byte("Message"), "just a test", "TEST", time.Now().UnixNano())
 			Expect(err).To(HaveOccurred())
@@ -59,7 +62,7 @@ var _ = Describe("HttpsWriter", func() {
 		It("holds onto the last error when unable to POST a log message", func() {
 			outputUrl, _ := url.Parse("https://")
 
-			w, _ := syslogwriter.NewHttpsWriter(outputUrl, "appId", true)
+			w, _ := syslogwriter.NewHttpsWriter(outputUrl, "appId", true, dialer)
 
 			_, err := w.Write(standardErrorPriority, []byte("Message"), "just a test", "TEST", time.Now().UnixNano())
 
@@ -71,7 +74,7 @@ var _ = Describe("HttpsWriter", func() {
 		It("should close connections and return an error if status code returned is not 200", func() {
 			outputUrl, _ := url.Parse(server.URL + "/doesnotexist")
 
-			w, _ := syslogwriter.NewHttpsWriter(outputUrl, "appId", true)
+			w, _ := syslogwriter.NewHttpsWriter(outputUrl, "appId", true, dialer)
 			err := w.Connect()
 			Expect(err).ToNot(HaveOccurred())
 
@@ -88,25 +91,53 @@ var _ = Describe("HttpsWriter", func() {
 		It("should not return error for response 200 status codes", func() {
 			outputUrl, _ := url.Parse(server.URL + "/234-bxg-234/")
 
-			w, _ := syslogwriter.NewHttpsWriter(outputUrl, "appId", true)
+			w, _ := syslogwriter.NewHttpsWriter(outputUrl, "appId", true, dialer)
 			err := w.Connect()
 			Expect(err).ToNot(HaveOccurred())
 
 			parsedTime, err := time.Parse(time.RFC3339, "2006-01-02T15:04:05Z")
 			_, err = w.Write(standardErrorPriority, []byte("Message"), "just a test", "TEST", parsedTime.UnixNano())
 			Expect(err).ToNot(HaveOccurred())
+		})
 
+		Context("when the target sink is slow to accept connections", func() {
+			var listener net.Listener
+
+			BeforeEach(func() {
+				var err error
+				listener, err = net.Listen("tcp", "127.0.0.1:0")
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			AfterEach(func() {
+				listener.Close()
+			})
+
+			It("times out", func() {
+				outputUrl, _ := url.Parse("https://" + listener.Addr().String() + "/")
+				w, err := syslogwriter.NewHttpsWriter(outputUrl, "appId", true, dialer)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = w.Connect()
+				Expect(err).NotTo(HaveOccurred())
+
+				parsedTime, err := time.Parse(time.RFC3339, "2006-01-02T15:04:05Z")
+				_, err = w.Write(standardErrorPriority, []byte("Message"), "just a test", "TEST", parsedTime.UnixNano())
+				Expect(err).To(BeAssignableToTypeOf(&url.Error{}))
+				urlErr := err.(*url.Error)
+				Expect(urlErr.Err).To(MatchError("net/http: TLS handshake timeout"))
+			})
 		})
 
 		It("returns an error for syslog-tls scheme", func() {
 			outputUrl, _ := url.Parse("syslog-tls://localhost")
-			_, err := syslogwriter.NewHttpsWriter(outputUrl, "appId", false)
+			_, err := syslogwriter.NewHttpsWriter(outputUrl, "appId", false, dialer)
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("returns an error for syslog scheme", func() {
 			outputUrl, _ := url.Parse("syslog://localhost")
-			_, err := syslogwriter.NewHttpsWriter(outputUrl, "appId", false)
+			_, err := syslogwriter.NewHttpsWriter(outputUrl, "appId", false, dialer)
 			Expect(err).To(HaveOccurred())
 		})
 	})

--- a/src/doppler/sinks/syslogwriter/writer.go
+++ b/src/doppler/sinks/syslogwriter/writer.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"strings"
 	"time"
@@ -23,14 +24,15 @@ type Writer interface {
 	Close() error
 }
 
-func NewWriter(outputUrl *url.URL, appId string, skipCertVerify bool) (Writer, error) {
+func NewWriter(outputUrl *url.URL, appId string, skipCertVerify bool, dialTimeout time.Duration) (Writer, error) {
+	dialer := &net.Dialer{Timeout: dialTimeout}
 	switch outputUrl.Scheme {
 	case "https":
-		return NewHttpsWriter(outputUrl, appId, skipCertVerify)
+		return NewHttpsWriter(outputUrl, appId, skipCertVerify, dialer)
 	case "syslog":
-		return NewSyslogWriter(outputUrl, appId)
+		return NewSyslogWriter(outputUrl, appId, dialer)
 	case "syslog-tls":
-		return NewTlsWriter(outputUrl, appId, skipCertVerify)
+		return NewTlsWriter(outputUrl, appId, skipCertVerify, dialer)
 	default:
 		return nil, errors.New(fmt.Sprintf("Invalid scheme type %s, must be https, syslog-tls or syslog", outputUrl.Scheme))
 	}

--- a/src/doppler/sinks/syslogwriter/writer_test.go
+++ b/src/doppler/sinks/syslogwriter/writer_test.go
@@ -2,6 +2,7 @@ package syslogwriter_test
 
 import (
 	"doppler/sinks/syslogwriter"
+	"time"
 
 	"net/url"
 	"reflect"
@@ -14,7 +15,7 @@ var _ = Describe("Writer", func() {
 
 	It("returns an syslogWriter for syslog scheme", func() {
 		outputUrl, _ := url.Parse("syslog://localhost:9999")
-		w, err := syslogwriter.NewWriter(outputUrl, "appId", false)
+		w, err := syslogwriter.NewWriter(outputUrl, "appId", false, 1*time.Second)
 		Expect(err).ToNot(HaveOccurred())
 		writerType := reflect.TypeOf(w).String()
 		Expect(writerType).To(Equal("*syslogwriter.syslogWriter"))
@@ -22,7 +23,7 @@ var _ = Describe("Writer", func() {
 
 	It("returns an tlsWriter for syslog-tls scheme", func() {
 		outputUrl, _ := url.Parse("syslog-tls://localhost:9999")
-		w, err := syslogwriter.NewWriter(outputUrl, "appId", false)
+		w, err := syslogwriter.NewWriter(outputUrl, "appId", false, 1*time.Second)
 		Expect(err).ToNot(HaveOccurred())
 		writerType := reflect.TypeOf(w).String()
 		Expect(writerType).To(Equal("*syslogwriter.tlsWriter"))
@@ -30,7 +31,7 @@ var _ = Describe("Writer", func() {
 
 	It("returns an httpsWriter for https scheme", func() {
 		outputUrl, _ := url.Parse("https://localhost:9999")
-		w, err := syslogwriter.NewWriter(outputUrl, "appId", false)
+		w, err := syslogwriter.NewWriter(outputUrl, "appId", false, 1*time.Second)
 		Expect(err).ToNot(HaveOccurred())
 		writerType := reflect.TypeOf(w).String()
 		Expect(writerType).To(Equal("*syslogwriter.httpsWriter"))
@@ -38,7 +39,7 @@ var _ = Describe("Writer", func() {
 
 	It("returns an error for invalid scheme", func() {
 		outputUrl, _ := url.Parse("notValid://localhost:9999")
-		w, err := syslogwriter.NewWriter(outputUrl, "appId", false)
+		w, err := syslogwriter.NewWriter(outputUrl, "appId", false, 1*time.Second)
 		Expect(err).To(HaveOccurred())
 		Expect(w).To(BeNil())
 	})

--- a/src/doppler/sinkserver/sinkmanager/sink_manager_test.go
+++ b/src/doppler/sinkserver/sinkmanager/sink_manager_test.go
@@ -8,6 +8,7 @@ import (
 	"doppler/sinks/syslogwriter"
 	"doppler/sinkserver/blacklist"
 	"doppler/sinkserver/sinkmanager"
+	"net"
 	"net/url"
 	"sync"
 	"time"
@@ -32,7 +33,7 @@ var _ = Describe("SinkManager", func() {
 
 	BeforeEach(func() {
 		fakeMetricSender.Reset()
-		sinkManager = sinkmanager.New(1, true, blackListManager, loggertesthelper.Logger(), 100, "dropsonde-origin", 1*time.Second, 1*time.Second)
+		sinkManager = sinkmanager.New(1, true, blackListManager, loggertesthelper.Logger(), 100, "dropsonde-origin", 1*time.Second, 1*time.Second, 1*time.Second)
 
 		newAppServiceChan = make(chan appservice.AppService)
 		deletedAppServiceChan = make(chan appservice.AppService)
@@ -293,7 +294,7 @@ var _ = Describe("SinkManager", func() {
 			BeforeEach(func() {
 				url, err := url.Parse("syslog://localhost:9998")
 				Expect(err).To(BeNil())
-				writer, _ := syslogwriter.NewSyslogWriter(url, "appId")
+				writer, _ := syslogwriter.NewSyslogWriter(url, "appId", &net.Dialer{Timeout: 500 * time.Millisecond})
 				syslogSink = syslog.NewSyslogSink("appId", "localhost:9999", loggertesthelper.Logger(), 100, writer, func(string, string, string) {}, "dropsonde-origin")
 
 				sinkManager.RegisterSink(syslogSink)

--- a/src/doppler/sinkserver/sinkserver_dump_test.go
+++ b/src/doppler/sinkserver/sinkserver_dump_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Dumping", func() {
 
 		emptyBlacklist := blacklist.New(nil)
 		sinkManager = sinkmanager.New(1024, false, emptyBlacklist, logger, 100, "dropsonde-origin",
-			2*time.Second, 1*time.Second)
+			2*time.Second, 1*time.Second, 500*time.Millisecond)
 
 		services.Add(1)
 		goRoutineSpawned.Add(1)

--- a/src/doppler/sinkserver/websocketserver/websocket_server_test.go
+++ b/src/doppler/sinkserver/websocketserver/websocket_server_test.go
@@ -22,7 +22,7 @@ import (
 var _ = Describe("WebsocketServer", func() {
 
 	var server *websocketserver.WebsocketServer
-	var sinkManager = sinkmanager.New(1024, false, blacklist.New(nil), loggertesthelper.Logger(), 100, "dropsonde-origin", 1*time.Second, 1*time.Second)
+	var sinkManager = sinkmanager.New(1024, false, blacklist.New(nil), loggertesthelper.Logger(), 100, "dropsonde-origin", 1*time.Second, 1*time.Second, 500*time.Millisecond)
 	var appId = "my-app"
 	var wsReceivedChan chan []byte
 	var connectionDropped <-chan struct{}


### PR DESCRIPTION
We noticed in our logs that the 500ms dialer timeout was causing failures because it would take just a bit longer.  We also noticed that some sinks were missing dial timeout entirely.

This change exposes a setting to configure the timeout and makes it consistent across all the sinks.