### PR TITLE
I/O timeouts for sinks

### DIFF
--- a/bosh/jobs/doppler/spec
+++ b/bosh/jobs/doppler/spec
@@ -52,6 +52,9 @@ properties:
   doppler.sink_dial_timeout_seconds:
     description: "Dial timeout for sinks"
     default: 1
+  doppler.sink_io_timeout_seconds:
+    description: "I/O Timeout on sinks"
+    default: 0
   doppler_endpoint.shared_secret:
     description: "Shared secret used to verify cryptographically signed doppler messages"
   doppler.message_drain_buffer_size:

--- a/bosh/jobs/doppler/templates/doppler.json.erb
+++ b/bosh/jobs/doppler/templates/doppler.json.erb
@@ -16,6 +16,7 @@
   "ContainerMetricTTLSeconds": <%= p("doppler.container_metric_ttl_seconds") %>,
   "SinkInactivityTimeoutSeconds": <%= p("doppler.sink_inactivity_timeout_seconds") %>,
   "SinkDialTimeoutSeconds": <%= p("doppler.sink_dial_timeout_seconds") %>,
+  "SinkIOTimeoutSeconds": <%= p("doppler.sink_io_timeout_seconds") %>,
   "UnmarshallerCount": <%= p("doppler.unmarshaller_count") %>,
 
   "MetronAddress": "<%= p("metron_endpoint.host") %>:<%= p("metron_endpoint.dropsonde_port") %>",

--- a/src/doppler/config/config.go
+++ b/src/doppler/config/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	Zone                          string
 	ContainerMetricTTLSeconds     int
 	SinkInactivityTimeoutSeconds  int
+	SinkIOTimeoutSeconds          int
 	UnmarshallerCount             int
 	MetronAddress                 string
 	MonitorIntervalSeconds        uint

--- a/src/doppler/doppler.go
+++ b/src/doppler/doppler.go
@@ -66,7 +66,8 @@ func New(host string, config *config.Config, logger *gosteno.Logger, storeAdapte
 	blacklist := blacklist.New(config.BlackListIps)
 	metricTTL := time.Duration(config.ContainerMetricTTLSeconds) * time.Second
 	sinkTimeout := time.Duration(config.SinkInactivityTimeoutSeconds) * time.Second
-	sinkManager := sinkmanager.New(config.MaxRetainedLogMessages, config.SkipCertVerify, blacklist, logger, messageDrainBufferSize, dropsondeOrigin, sinkTimeout, metricTTL, dialTimeout)
+	sinkIOTimeout := time.Duration(config.SinkIOTimeoutSeconds) * time.Second
+	sinkManager := sinkmanager.New(config.MaxRetainedLogMessages, config.SkipCertVerify, blacklist, logger, messageDrainBufferSize, dropsondeOrigin, sinkTimeout, sinkIOTimeout, metricTTL, dialTimeout)
 
 	return &Doppler{
 		Logger:                          logger,

--- a/src/doppler/sinks/syslog/syslog_sink_test.go
+++ b/src/doppler/sinks/syslog/syslog_sink_test.go
@@ -282,7 +282,7 @@ var _ = Describe("SyslogSink", func() {
 			}))
 			url, _ := url.Parse(server.URL)
 
-			httpsWriter, err := syslogwriter.NewHttpsWriter(url, appId, true, dialer)
+			httpsWriter, err := syslogwriter.NewHttpsWriter(url, appId, true, dialer, 0)
 			Expect(err).ToNot(HaveOccurred())
 
 			errorHandler := func(string, string, string) {}

--- a/src/doppler/sinks/syslogwriter/https_writer.go
+++ b/src/doppler/sinks/syslogwriter/https_writer.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"time"
 )
 
 type httpsWriter struct {
@@ -27,7 +28,7 @@ type httpsWriter struct {
 	lastError error
 }
 
-func NewHttpsWriter(outputUrl *url.URL, appId string, skipCertVerify bool, dialer *net.Dialer) (w *httpsWriter, err error) {
+func NewHttpsWriter(outputUrl *url.URL, appId string, skipCertVerify bool, dialer *net.Dialer, timeout time.Duration) (w *httpsWriter, err error) {
 	if dialer == nil {
 		return nil, errors.New("cannot construct a writer with a nil dialer")
 	}
@@ -43,7 +44,7 @@ func NewHttpsWriter(outputUrl *url.URL, appId string, skipCertVerify bool, diale
 			return dialer.Dial(network, addr)
 		},
 	}
-	client := &http.Client{Transport: tr}
+	client := &http.Client{Transport: tr, Timeout: timeout}
 	return &httpsWriter{
 		appId:     appId,
 		outputUrl: outputUrl,

--- a/src/doppler/sinks/syslogwriter/syslog_writer_test.go
+++ b/src/doppler/sinks/syslogwriter/syslog_writer_test.go
@@ -19,15 +19,15 @@ var _ = Describe("SyslogWriter", func() {
 
 	var sysLogWriter syslogwriter.Writer
 	var dialer *net.Dialer
-
 	var syslogServerSession *gexec.Session
+
 	BeforeEach(func(done Done) {
 		dialer = &net.Dialer{
 			Timeout: 500 * time.Millisecond,
 		}
 		outputURL, _ := url.Parse("syslog://127.0.0.1:9999")
 		syslogServerSession = startSyslogServer("127.0.0.1:9999")
-		sysLogWriter, _ = syslogwriter.NewSyslogWriter(outputURL, "appId", dialer)
+		sysLogWriter, _ = syslogwriter.NewSyslogWriter(outputURL, "appId", dialer, 0)
 
 		Eventually(func() error {
 			err := sysLogWriter.Connect()
@@ -78,20 +78,20 @@ var _ = Describe("SyslogWriter", func() {
 
 	It("returns an error when the provided dialer is nil", func() {
 		outputURL, _ := url.Parse("syslog://localhost")
-		_, err := syslogwriter.NewSyslogWriter(outputURL, "appId", nil)
+		_, err := syslogwriter.NewSyslogWriter(outputURL, "appId", nil, 0)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("cannot construct a writer with a nil dialer"))
 	})
 
 	It("returns an error for syslog-tls scheme", func() {
 		outputURL, _ := url.Parse("syslog-tls://localhost")
-		_, err := syslogwriter.NewSyslogWriter(outputURL, "appId", dialer)
+		_, err := syslogwriter.NewSyslogWriter(outputURL, "appId", dialer, 0)
 		Expect(err).To(HaveOccurred())
 	})
 
 	It("returns an error for https scheme", func() {
 		outputURL, _ := url.Parse("https://localhost")
-		_, err := syslogwriter.NewSyslogWriter(outputURL, "appId", dialer)
+		_, err := syslogwriter.NewSyslogWriter(outputURL, "appId", dialer, 0)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -129,12 +129,17 @@ var _ = Describe("SyslogWriter", func() {
 		})
 	})
 
-	Context("when the server connection closes", func() {
+	Describe("network timeouts", func() {
 		var listener net.Listener
 		var acceptedConns chan net.Conn
 		var sysLogWriter syslogwriter.Writer
+		var writeTimeout time.Duration
 
 		BeforeEach(func() {
+			writeTimeout = 0
+		})
+
+		JustBeforeEach(func() {
 			var err error
 			listener, err = net.Listen("tcp", "127.0.0.1:0")
 			Expect(err).NotTo(HaveOccurred())
@@ -142,7 +147,7 @@ var _ = Describe("SyslogWriter", func() {
 			url, err := url.Parse("syslog://" + listener.Addr().String())
 			Expect(err).NotTo(HaveOccurred())
 
-			sysLogWriter, err = syslogwriter.NewSyslogWriter(url, "appId", dialer)
+			sysLogWriter, err = syslogwriter.NewSyslogWriter(url, "appId", dialer, writeTimeout)
 			Expect(err).NotTo(HaveOccurred())
 
 			acceptedConns = make(chan net.Conn, 1)
@@ -157,28 +162,43 @@ var _ = Describe("SyslogWriter", func() {
 			sysLogWriter.Close()
 		})
 
-		It("gets detected by watch connection", func() {
-			written, err := sysLogWriter.Write(standardOutPriority, []byte("just a test"), "App", "2", time.Now().UnixNano())
-			Expect(err).NotTo(HaveOccurred())
-			Expect(written).NotTo(Equal(0))
+		Context("when the drain is slow to consume", func() {
+			BeforeEach(func() {
+				// force an immediate write timeout
+				writeTimeout = -1 * time.Second
+			})
 
-			var conn net.Conn
-			Eventually(acceptedConns).Should(Receive(&conn))
-
-			err = conn.Close()
-			Expect(err).NotTo(HaveOccurred())
-
-			Eventually(func() error {
+			It("returns an error after the write deadline expires", func() {
 				_, err := sysLogWriter.Write(standardOutPriority, []byte("just a test"), "App", "2", time.Now().UnixNano())
-				return err
-			}).Should(MatchError("Connection to syslog sink lost"))
+				opErr := err.(*net.OpError)
+				Expect(opErr.Timeout()).To(BeTrue())
+			})
+		})
 
-			err = sysLogWriter.Connect()
-			Expect(err).NotTo(HaveOccurred())
+		Context("when the server connection closes", func() {
+			It("gets detected by watch connection", func() {
+				written, err := sysLogWriter.Write(standardOutPriority, []byte("just a test"), "App", "2", time.Now().UnixNano())
+				Expect(err).NotTo(HaveOccurred())
+				Expect(written).NotTo(Equal(0))
 
-			written, err = sysLogWriter.Write(standardOutPriority, []byte("just a test"), "App", "2", time.Now().UnixNano())
-			Expect(err).NotTo(HaveOccurred())
-			Expect(written).NotTo(Equal(0))
+				var conn net.Conn
+				Eventually(acceptedConns).Should(Receive(&conn))
+
+				err = conn.Close()
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(func() error {
+					_, err := sysLogWriter.Write(standardOutPriority, []byte("just a test"), "App", "2", time.Now().UnixNano())
+					return err
+				}).Should(MatchError("Connection to syslog sink lost"))
+
+				err = sysLogWriter.Connect()
+				Expect(err).NotTo(HaveOccurred())
+
+				written, err = sysLogWriter.Write(standardOutPriority, []byte("just a test"), "App", "2", time.Now().UnixNano())
+				Expect(err).NotTo(HaveOccurred())
+				Expect(written).NotTo(Equal(0))
+			})
 		})
 	})
 

--- a/src/doppler/sinks/syslogwriter/syslog_writer_test.go
+++ b/src/doppler/sinks/syslogwriter/syslog_writer_test.go
@@ -13,11 +13,12 @@ import (
 	"github.com/onsi/gomega/gexec"
 )
 
+const standardOutPriority = 14
+
 var _ = Describe("SyslogWriter", func() {
 
 	var sysLogWriter syslogwriter.Writer
 	var dialer *net.Dialer
-	standardOutPriority := 14
 
 	var syslogServerSession *gexec.Session
 	BeforeEach(func(done Done) {

--- a/src/doppler/sinks/syslogwriter/writer.go
+++ b/src/doppler/sinks/syslogwriter/writer.go
@@ -24,15 +24,15 @@ type Writer interface {
 	Close() error
 }
 
-func NewWriter(outputUrl *url.URL, appId string, skipCertVerify bool, dialTimeout time.Duration) (Writer, error) {
+func NewWriter(outputUrl *url.URL, appId string, skipCertVerify bool, dialTimeout time.Duration, ioTimeout time.Duration) (Writer, error) {
 	dialer := &net.Dialer{Timeout: dialTimeout}
 	switch outputUrl.Scheme {
 	case "https":
-		return NewHttpsWriter(outputUrl, appId, skipCertVerify, dialer)
+		return NewHttpsWriter(outputUrl, appId, skipCertVerify, dialer, ioTimeout)
 	case "syslog":
-		return NewSyslogWriter(outputUrl, appId, dialer)
+		return NewSyslogWriter(outputUrl, appId, dialer, ioTimeout)
 	case "syslog-tls":
-		return NewTlsWriter(outputUrl, appId, skipCertVerify, dialer)
+		return NewTlsWriter(outputUrl, appId, skipCertVerify, dialer, ioTimeout)
 	default:
 		return nil, errors.New(fmt.Sprintf("Invalid scheme type %s, must be https, syslog-tls or syslog", outputUrl.Scheme))
 	}

--- a/src/doppler/sinks/syslogwriter/writer_test.go
+++ b/src/doppler/sinks/syslogwriter/writer_test.go
@@ -15,7 +15,7 @@ var _ = Describe("Writer", func() {
 
 	It("returns an syslogWriter for syslog scheme", func() {
 		outputUrl, _ := url.Parse("syslog://localhost:9999")
-		w, err := syslogwriter.NewWriter(outputUrl, "appId", false, 1*time.Second)
+		w, err := syslogwriter.NewWriter(outputUrl, "appId", false, 1*time.Second, 0)
 		Expect(err).ToNot(HaveOccurred())
 		writerType := reflect.TypeOf(w).String()
 		Expect(writerType).To(Equal("*syslogwriter.syslogWriter"))
@@ -23,7 +23,7 @@ var _ = Describe("Writer", func() {
 
 	It("returns an tlsWriter for syslog-tls scheme", func() {
 		outputUrl, _ := url.Parse("syslog-tls://localhost:9999")
-		w, err := syslogwriter.NewWriter(outputUrl, "appId", false, 1*time.Second)
+		w, err := syslogwriter.NewWriter(outputUrl, "appId", false, 1*time.Second, 0)
 		Expect(err).ToNot(HaveOccurred())
 		writerType := reflect.TypeOf(w).String()
 		Expect(writerType).To(Equal("*syslogwriter.tlsWriter"))
@@ -31,7 +31,7 @@ var _ = Describe("Writer", func() {
 
 	It("returns an httpsWriter for https scheme", func() {
 		outputUrl, _ := url.Parse("https://localhost:9999")
-		w, err := syslogwriter.NewWriter(outputUrl, "appId", false, 1*time.Second)
+		w, err := syslogwriter.NewWriter(outputUrl, "appId", false, 1*time.Second, 0)
 		Expect(err).ToNot(HaveOccurred())
 		writerType := reflect.TypeOf(w).String()
 		Expect(writerType).To(Equal("*syslogwriter.httpsWriter"))
@@ -39,7 +39,7 @@ var _ = Describe("Writer", func() {
 
 	It("returns an error for invalid scheme", func() {
 		outputUrl, _ := url.Parse("notValid://localhost:9999")
-		w, err := syslogwriter.NewWriter(outputUrl, "appId", false, 1*time.Second)
+		w, err := syslogwriter.NewWriter(outputUrl, "appId", false, 1*time.Second, 0)
 		Expect(err).To(HaveOccurred())
 		Expect(w).To(BeNil())
 	})

--- a/src/doppler/sinkserver/sinkmanager/sink_manager_test.go
+++ b/src/doppler/sinkserver/sinkmanager/sink_manager_test.go
@@ -33,7 +33,7 @@ var _ = Describe("SinkManager", func() {
 
 	BeforeEach(func() {
 		fakeMetricSender.Reset()
-		sinkManager = sinkmanager.New(1, true, blackListManager, loggertesthelper.Logger(), 100, "dropsonde-origin", 1*time.Second, 1*time.Second, 1*time.Second)
+		sinkManager = sinkmanager.New(1, true, blackListManager, loggertesthelper.Logger(), 100, "dropsonde-origin", 1*time.Second, 0, 1*time.Second, 1*time.Second)
 
 		newAppServiceChan = make(chan appservice.AppService)
 		deletedAppServiceChan = make(chan appservice.AppService)
@@ -294,7 +294,7 @@ var _ = Describe("SinkManager", func() {
 			BeforeEach(func() {
 				url, err := url.Parse("syslog://localhost:9998")
 				Expect(err).To(BeNil())
-				writer, _ := syslogwriter.NewSyslogWriter(url, "appId", &net.Dialer{Timeout: 500 * time.Millisecond})
+				writer, _ := syslogwriter.NewSyslogWriter(url, "appId", &net.Dialer{Timeout: 500 * time.Millisecond}, 0)
 				syslogSink = syslog.NewSyslogSink("appId", "localhost:9999", loggertesthelper.Logger(), 100, writer, func(string, string, string) {}, "dropsonde-origin")
 
 				sinkManager.RegisterSink(syslogSink)

--- a/src/doppler/sinkserver/sinkserver_dump_test.go
+++ b/src/doppler/sinkserver/sinkserver_dump_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Dumping", func() {
 
 		emptyBlacklist := blacklist.New(nil)
 		sinkManager = sinkmanager.New(1024, false, emptyBlacklist, logger, 100, "dropsonde-origin",
-			2*time.Second, 1*time.Second, 500*time.Millisecond)
+			2*time.Second, 0, 1*time.Second, 500*time.Millisecond)
 
 		services.Add(1)
 		goRoutineSpawned.Add(1)

--- a/src/doppler/sinkserver/websocketserver/websocket_server_test.go
+++ b/src/doppler/sinkserver/websocketserver/websocket_server_test.go
@@ -22,7 +22,7 @@ import (
 var _ = Describe("WebsocketServer", func() {
 
 	var server *websocketserver.WebsocketServer
-	var sinkManager = sinkmanager.New(1024, false, blacklist.New(nil), loggertesthelper.Logger(), 100, "dropsonde-origin", 1*time.Second, 1*time.Second, 500*time.Millisecond)
+	var sinkManager = sinkmanager.New(1024, false, blacklist.New(nil), loggertesthelper.Logger(), 100, "dropsonde-origin", 1*time.Second, 0, 1*time.Second, 500*time.Millisecond)
 	var appId = "my-app"
 	var wsReceivedChan chan []byte
 	var connectionDropped <-chan struct{}


### PR DESCRIPTION
Provide the ability to timeout sink operations.

We currently left the default to be the same as it is now which is nothing, however, it might be prudent to set some meaningful default to prevent slow consumers which is what we were seeing.