### PR TITLE
Enable to add custom syslog forwading rule

### DIFF
--- a/bosh/jobs/metron_agent/spec
+++ b/bosh/jobs/metron_agent/spec
@@ -21,6 +21,9 @@ properties:
   syslog_daemon_config.fallback_addresses:
     description: "Addresses of fallback servers to be used if the primary syslog server is down. Only tcp or relp are supported. Each list entry should consist of \"address\", \"transport\" and \"port\" keys. "
     default: []
+  syslog_daemon_config.custom_rule:
+    description: "Custom rule for syslog forward daemon"
+    default: ""
 
   metron_agent.incoming_port:
     description: "Incoming port for legacy log messages"

--- a/bosh/jobs/metron_agent/templates/syslog_forwarder.conf.erb
+++ b/bosh/jobs/metron_agent/templates/syslog_forwarder.conf.erb
@@ -47,6 +47,8 @@ template(name="CfLogTemplate" type="list") {
         property(name="msg")
 }
 
+<%= p('syslog_daemon_config.custom_rule') %>
+
 <% if_p("syslog_daemon_config.address", "syslog_daemon_config.port", "syslog_daemon_config.transport") do |address, port, transport| %>
 
 <% if transport == "relp" %>


### PR DESCRIPTION
We want to forward syslog to other components directly without internal servers (e.g., forwarding [Apache kafka](http://kafka.apache.org/) with [omkafka](http://www.rsyslog.com/doc/master/configuration/modules/omkafka.html)). To support this kind of setup, it's great if `syslog_forwarder.conf`accepts arbitrary custom rule. 