### PR TITLE
Use route_registrar job for registering routes

### DIFF
--- a/manifest-templates/cf-lamb.yml
+++ b/manifest-templates/cf-lamb.yml
@@ -18,6 +18,8 @@ lamb_meta:
     release: (( lamb_meta.release.name ))
   - name: metron_agent
     release: (( lamb_meta.release.name ))
+  - name: route_registrar
+    release: (( lamb_meta.release.name ))
 
 jobs:
 - name: loggregator_z1
@@ -54,6 +56,16 @@ jobs:
       zone: z1
     metron_agent:
       zone: z1
+    route_registrar:
+      routes:
+      - name: doppler
+        port: 8081
+        uris:
+        - (( "doppler." .properties.domain ))
+      - name: loggregator
+        port: 8080
+        uris:
+        - (( "loggregator." .properties.domain ))
 
 - name: loggregator_trafficcontroller_z2
   properties:
@@ -61,6 +73,16 @@ jobs:
       zone: z2
     metron_agent:
       zone: z2
+    route_registrar:
+      routes:
+      - name: doppler
+        port: 8081
+        uris:
+        - (( "doppler." .properties.domain ))
+      - name: loggregator
+        port: 8080
+        uris:
+        - (( "loggregator." .properties.domain ))
 
 properties:
   <<: (( merge ))

--- a/manifest-templates/cf-lamb.yml
+++ b/manifest-templates/cf-lamb.yml
@@ -59,11 +59,11 @@ jobs:
     route_registrar:
       routes:
       - name: doppler
-        port: 8081
+        port: (( .properties.loggregator.outgoing_dropsonde_port ))
         uris:
         - (( "doppler." .properties.domain ))
       - name: loggregator
-        port: 8080
+        port: (( .properties.traffic_controller.outgoing_port ))
         uris:
         - (( "loggregator." .properties.domain ))
 
@@ -76,11 +76,11 @@ jobs:
     route_registrar:
       routes:
       - name: doppler
-        port: 8081
+        port: (( .properties.loggregator.outgoing_dropsonde_port ))
         uris:
         - (( "doppler." .properties.domain ))
       - name: loggregator
-        port: 8080
+        port: (( .properties.traffic_controller.outgoing_port ))
         uris:
         - (( "loggregator." .properties.domain ))
 
@@ -91,6 +91,7 @@ properties:
     maxRetainedLogMessages: 100
     debug: (( merge || false ))
     blacklisted_syslog_ranges: ~
+    outgoing_dropsonde_port: 8081
 
   doppler:
     maxRetainedLogMessages: 100
@@ -101,3 +102,6 @@ properties:
 
   metron_agent:
     deployment: (( meta.environment ))
+
+  traffic_controller:
+    outgoing_port: 8080

--- a/manifest-templates/lamb-properties.rb
+++ b/manifest-templates/lamb-properties.rb
@@ -29,6 +29,16 @@ class LambProperties
       zone: z1
     traffic_controller:
       zone: z1
+    route_registrar:
+      routes:
+      - name: doppler
+        port: 8081
+        uris:
+        - doppler.#{system_domain}
+      - name: loggregator
+        port: 8080
+        uris:
+        - loggregator.#{system_domain}
     EOF
     result.chomp
   end
@@ -39,6 +49,16 @@ class LambProperties
       zone: z2
     traffic_controller:
       zone: z2
+    route_registrar:
+      routes:
+      - name: doppler
+        port: 8081
+        uris:
+        - doppler.#{system_domain}
+      - name: loggregator
+        port: 8080
+        uris:
+        - loggregator.#{system_domain}
     EOF
     result.chomp
   end
@@ -60,6 +80,8 @@ class LambProperties
     - name: loggregator_trafficcontroller
       release: cf
     - name: metron_agent
+      release: cf
+    - name: route_registrar
       release: cf
     EOF
     result.chomp
@@ -107,6 +129,17 @@ class LambProperties
     deployment: #{deployment_name}
     EOF
     result.chomp
+  end
+
+  def system_domain
+    case @infrastructure
+      when "vsphere"
+        "0.0.0.3.xip.io"
+      when "warden"
+        "10.244.0.34.xip.io"
+      else
+        "example.com"
+    end
   end
 
   def get_binding

--- a/manifest-templates/lamb-properties.rb
+++ b/manifest-templates/lamb-properties.rb
@@ -95,6 +95,7 @@ class LambProperties
     blacklisted_syslog_ranges:
     - start: 10.10.0.0
       end: 10.10.255.255
+    outgoing_dropsonde_port: 8081
 
   doppler:
     maxRetainedLogMessages: 100
@@ -105,6 +106,9 @@ class LambProperties
 
   metron_agent:
     deployment: #{deployment_name}
+
+  traffic_controller:
+    outgoing_port: 8080
     EOF
     result.chomp
   end
@@ -117,6 +121,7 @@ class LambProperties
     maxRetainedLogMessages: 100
     debug: false
     blacklisted_syslog_ranges: null
+    outgoing_dropsonde_port: 8081
 
   doppler:
     maxRetainedLogMessages: 100
@@ -127,6 +132,9 @@ class LambProperties
 
   metron_agent:
     deployment: #{deployment_name}
+
+  traffic_controller:
+    outgoing_port: 8080
     EOF
     result.chomp
   end


### PR DESCRIPTION
We've extracted a job template for doing route registration via manifest properties. Slack us in mega if you have any questions.

You should be able to remove any route registration code you currently use once this is merged.