### PR TITLE
Remove dangling references to syslog drain URLs in DEA agent

### DIFF
--- a/src/deaagent/agent.go
+++ b/src/deaagent/agent.go
@@ -2,13 +2,14 @@ package deaagent
 
 import (
 	"deaagent/domain"
-	"github.com/cloudfoundry/dropsonde/metrics"
-	"github.com/cloudfoundry/gosteno"
-	"github.com/howeyc/fsnotify"
 	"io/ioutil"
 	"path"
 	"sync"
 	"time"
+
+	"github.com/cloudfoundry/dropsonde/metrics"
+	"github.com/cloudfoundry/gosteno"
+	"github.com/howeyc/fsnotify"
 )
 
 type Agent struct {
@@ -57,19 +58,12 @@ func (agent *Agent) processTasks(currentTasks map[string]domain.Task) func(known
 		}
 
 		for _, task := range currentTasks {
-			drainUrls := task.DrainUrls
-			if drainUrls == nil {
-				drainUrls = []string{}
-			}
-
 			identifier := task.Identifier()
 			_, present := knownTasks[identifier]
 
 			if present {
 				continue
 			}
-
-			task.DrainUrls = nil
 
 			agent.logger.Debugf("Adding new task %s", task.Identifier())
 			listener, err := NewTaskListener(task, agent.logger)

--- a/src/deaagent/domain/task.go
+++ b/src/deaagent/domain/task.go
@@ -7,7 +7,6 @@ import (
 
 type Task struct {
 	ApplicationId       string
-	DrainUrls           []string
 	Index               uint64
 	WardenJobId         uint64
 	WardenContainerPath string

--- a/src/deaagent/domain/tasks_reader.go
+++ b/src/deaagent/domain/tasks_reader.go
@@ -12,7 +12,6 @@ func ReadTasks(data []byte) (map[string]Task, error) {
 		Warden_container_path string
 		Instance_index        uint64
 		State                 string
-		Syslog_drain_urls     []string
 	}
 
 	type stagingMessageJson struct {
@@ -23,7 +22,6 @@ func ReadTasks(data []byte) (map[string]Task, error) {
 		Staging_message       stagingMessageJson
 		Warden_job_id         uint64
 		Warden_container_path string
-		Syslog_drain_urls     []string
 	}
 
 	type instancesJson struct {
@@ -53,7 +51,7 @@ func ReadTasks(data []byte) (map[string]Task, error) {
 				WardenContainerPath: jsonInstance.Warden_container_path,
 				WardenJobId:         jsonInstance.Warden_job_id,
 				Index:               jsonInstance.Instance_index,
-				DrainUrls:           jsonInstance.Syslog_drain_urls}
+			}
 			tasks[task.Identifier()] = task
 		}
 	}
@@ -67,7 +65,7 @@ func ReadTasks(data []byte) (map[string]Task, error) {
 			SourceName:          "STG",
 			WardenContainerPath: jsonStagingTask.Warden_container_path,
 			WardenJobId:         jsonStagingTask.Warden_job_id,
-			DrainUrls:           jsonStagingTask.Syslog_drain_urls}
+		}
 		tasks[task.Identifier()] = task
 	}
 

--- a/src/deaagent/domain/tasks_reader_test.go
+++ b/src/deaagent/domain/tasks_reader_test.go
@@ -2,11 +2,12 @@ package domain_test
 
 import (
 	"deaagent/domain"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	"io/ioutil"
 	"path"
 	"runtime"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 func getJsonFromSampleFilePath(filename string) []byte {
@@ -29,14 +30,14 @@ var _ = Describe("ReadTasks", func() {
 			WardenJobId:         272,
 			WardenContainerPath: "/var/vcap/data/warden/depot/16vbs06ibo1",
 			SourceName:          "App",
-			DrainUrls:           []string{}}
+		}
 
 		expectedStagingTask := domain.Task{
 			ApplicationId:       "23489sd0-f985-fjga-nsd1-sdg5lhd9nskh",
 			WardenJobId:         355,
 			WardenContainerPath: "/var/vcap/data/warden/depot/16vbs06ibo2",
 			SourceName:          "STG",
-			DrainUrls:           []string{}}
+		}
 
 		Expect(tasks["/var/vcap/data/warden/depot/16vbs06ibo1/jobs/272"]).To(Equal(expectedInstanceTask))
 		Expect(tasks["/var/vcap/data/warden/depot/16vbs06ibo2/jobs/355"]).To(Equal(expectedStagingTask))
@@ -73,17 +74,8 @@ var _ = Describe("ReadTasks", func() {
 	})
 
 	It("reads multiple tasks with drain urls", func() {
-		tasks, err := domain.ReadTasks(getJsonFromSampleFilePath("multi_instances.json"))
-
+		_, err := domain.ReadTasks(getJsonFromSampleFilePath("multi_instances.json"))
 		Expect(err).NotTo(HaveOccurred())
-
-		Expect(tasks["/var/vcap/data/warden/depot/170os7ali6q/jobs/15"].DrainUrls).To(BeNil())
-		Expect(tasks["/var/vcap/data/warden/depot/123ajkljfa/jobs/13"].DrainUrls).To(BeEmpty())
-		Expect(tasks["/var/vcap/data/warden/depot/345asndhaena/jobs/12"].DrainUrls).To(ConsistOf("syslog://10.20.30.40:8050"))
-
-		Expect(tasks["/var/vcap/data/warden/depot/17fsdo7qpeq/jobs/46"].DrainUrls).To(BeNil())
-		Expect(tasks["/var/vcap/data/warden/depot/17fsdo7qper/jobs/49"].DrainUrls).To(BeEmpty())
-		Expect(tasks["/var/vcap/data/warden/depot/17fsdo7qpes/jobs/56"].DrainUrls).To(ConsistOf("syslog://10.20.30.40:8050"))
 	})
 
 	It("reads starting tasks", func() {

--- a/src/deaagent/task_listener_test.go
+++ b/src/deaagent/task_listener_test.go
@@ -3,10 +3,11 @@ package deaagent_test
 import (
 	"deaagent"
 	"deaagent/domain"
-	"github.com/cloudfoundry/loggregatorlib/loggertesthelper"
 	"io/ioutil"
 	"net"
 	"os"
+
+	"github.com/cloudfoundry/loggregatorlib/loggertesthelper"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -259,7 +260,7 @@ func setupTask(index uint64) (appTask *domain.Task, tmpdir string) {
 		WardenContainerPath: tmpdir,
 		Index:               index,
 		SourceName:          "App",
-		DrainUrls:           []string{"syslog://10.20.30.40:8050"}}
+	}
 
 	os.MkdirAll(appTask.Identifier(), 0777)
 


### PR DESCRIPTION
There appear to be some leftover references to the syslog drain URLs in the DEA agent that may have been missed in commit 7a79a415ac28f9770b6ac0e617a430d8c2972a30. This confused me a bit as I was walking the code (particularly the current task loop agent.go where it's tested for nil, assigned to an empty slice, never read, and then set back to nil).