### PR TITLE
Resend the previous message when reconnecting

### DIFF
--- a/src/doppler/sinks/syslog/syslog_sink_integration_test.go
+++ b/src/doppler/sinks/syslog/syslog_sink_integration_test.go
@@ -1,0 +1,74 @@
+package syslog_test
+
+import (
+	"doppler/sinks/syslog"
+	"doppler/sinks/syslogwriter"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"time"
+
+	"github.com/cloudfoundry/dropsonde/emitter"
+	"github.com/cloudfoundry/dropsonde/factories"
+	"github.com/cloudfoundry/loggregatorlib/loggertesthelper"
+	"github.com/cloudfoundry/sonde-go/events"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("SyslogSinkIntegration", func() {
+	Describe("HTTPS writer", func() {
+		Context("with non-200 return codes", func() {
+			It("backs off", func() {
+				bufferSize := uint(6)
+				appId := "appId"
+				var timestampsInMillis []int64
+				var requests int64
+
+				server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(400)
+					timestampsInMillis = append(timestampsInMillis, time.Now().UnixNano()/1e6)
+					atomic.AddInt64(&requests, 1)
+				}))
+				url, _ := url.Parse(server.URL)
+
+				dialer := &net.Dialer{}
+				httpsWriter, err := syslogwriter.NewHttpsWriter(url, appId, true, dialer, 0)
+				Expect(err).ToNot(HaveOccurred())
+
+				errorHandler := func(errorMsg string, appId string, drainUrl string) {}
+
+				syslogSink := syslog.NewSyslogSink(appId, server.URL, loggertesthelper.Logger(), bufferSize, httpsWriter, errorHandler, "dropsonde-origin")
+				inputChan := make(chan *events.Envelope)
+
+				defer syslogSink.Disconnect()
+				go syslogSink.Run(inputChan)
+
+				for i := 0; i < int(bufferSize); i++ {
+					msg := fmt.Sprintf("message number %v", i)
+					logMessage, _ := emitter.Wrap(factories.NewLogMessage(events.LogMessage_OUT, msg, appId, "App"), "origin")
+
+					inputChan <- logMessage
+				}
+				close(inputChan)
+
+				Eventually(func() int64 {
+					return atomic.LoadInt64(&requests)
+				}).Should(BeEquivalentTo(bufferSize))
+
+				// We ignore the difference in timestamps for the 0th iteration because our exponential backoff
+				// strategy starts of with a difference of 1 ms
+				var diff, prevDiff int64
+				for i := 1; i < len(timestampsInMillis)-1; i++ {
+					diff = timestampsInMillis[i+1] - timestampsInMillis[i]
+					Expect(diff).To(BeNumerically(">", 2*prevDiff))
+					prevDiff = diff
+				}
+			})
+		})
+	})
+})


### PR DESCRIPTION
When the connection is lost, resend the previous message.
The rework also changed the behavior to connect only when a message appears rather than connect regardless of whether a message is present.

I did some test cleanup in the process. 