### PR TITLE
Fixed typographical error, changed adminstrator to administrator in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ properties:
 
 ### Configuring the Firehose
 
-The firehose feature includes the combined stream of logs from all apps, plus metrics data from CF components, and is intended to be used by operators and adminstrators.
+The firehose feature includes the combined stream of logs from all apps, plus metrics data from CF components, and is intended to be used by operators and administrators.
 
 Access to the firehose requires a user with the `doppler.firehose` scope.
 


### PR DESCRIPTION
@cloudfoundry, I've corrected a typographical error in the documentation of the [loggregator](https://github.com/cloudfoundry/loggregator) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.