### PR TITLE
Ensure Doppler service is no longer published at shutdown

### DIFF
--- a/src/doppler/main.go
+++ b/src/doppler/main.go
@@ -132,9 +132,10 @@ func main() {
 			logger.DumpGoRoutine()
 		case <-killChan:
 			log.Info("Shutting down")
-			doppler.Stop()
 			close(releaseNodeChan)
 			close(legacyReleaseNodeChan)
+			time.Sleep(config.HeartbeatInterval)
+			doppler.Stop()
 			return
 		}
 	}


### PR DESCRIPTION
Closing the channels signals to the Announcers that they should stop and
remove the advertised service key. Doing this after stopping Doppler
meant that data could still be being sent from Metron to Doppler for the
small interval while the keys were being unregistered and propagated
through etcd to the Metron agents.

Simply moving the doppler.Stop() call after the channel closes reduces
the time period when data can be lost, but does not take into account
the propagation delay through etcd. Introducing a short wait the same
length as the key expiry seems the correct way to deal with this.