### PR TITLE
Added merge for zone to common properties

### DIFF
--- a/manifest-templates/cf-lamb.yml
+++ b/manifest-templates/cf-lamb.yml
@@ -101,6 +101,7 @@ properties:
     unmarshaller_count: (( merge || 5 ))
     port: (( merge || 4443 ))
     enable_tls_transport: ~
+    zone: (( merge || nil ))
     tls_listener:
       port: ~
       cert: ~
@@ -112,3 +113,4 @@ properties:
 
   traffic_controller:
     outgoing_port: 8080
+    zone: (( merge || nil ))


### PR DESCRIPTION
While trying to move `doppler` or `loggregator_trafficcontroller` templates out of `doppler_z1` or `loggregator_trafficcontroller_z1` jobs, it loses `doppler.zone` and `traffic_controller.zone` properties, because it's configured explicitly in default jobs only. Moveover, these properties are mandatory, and does not have any default value.

Because of that, after moving `doppler` or `loggregator_trafficcontroller` templates out of it's default jobs we will face with error like that on deploying stage: `Error 100: Error filling in template `doppler.json.erb' for `nats_z1/0' (line 9: Can't find property ["doppler.zone"])`

My patch fixes that by adding a merge statement in the common properties subsection, which allowing us  to add these properties in the stub file.