### PR TITLE
Replace uaa.no_ssl with login.protocol

### DIFF
--- a/jobs/loggregator_trafficcontroller/spec
+++ b/jobs/loggregator_trafficcontroller/spec
@@ -29,9 +29,9 @@ properties:
     description: "Doppler's client secret to connect to UAA"
   uaa.url:
     description: "URL of UAA"
-  uaa.no_ssl:
-    description: "Do not use SSL to connect to UAA (used in case uaa.url is not set)"
-    default: false
+  login.protocol:
+    description: "Protocol to use to connect to UAA (used in case uaa.url is not set)"
+    default: https
   metron_endpoint.dropsonde_port:
     description: "The port used to emit dropsonde messages to the Metron agent"
     default: 3457

--- a/jobs/loggregator_trafficcontroller/templates/loggregator_trafficcontroller.json.erb
+++ b/jobs/loggregator_trafficcontroller/templates/loggregator_trafficcontroller.json.erb
@@ -11,7 +11,7 @@
     "ApiHost": "<%= p("cc.srv_api_uri") %>",
     "SystemDomain": "<%= p("system_domain") %>",
     "MetronPort": <%= p("metron_endpoint.dropsonde_port") %>,
-    <% scheme = p("uaa.no_ssl") ? "http" : "https"
+    <% scheme = p("login.protocol")
         domain = p("system_domain") %>
     "UaaHost": "<%= p("uaa.url", "#{scheme}://uaa.#{domain}") %>",
     "UaaClientId": "<%= p("doppler.uaa_client_id") %>",


### PR DESCRIPTION
We have consolidated these two properties and now there is just one property login.protocol that should be used for building external facing urls. 