### PR TITLE
Fix Truncating Buffer race condition bug

### DIFF
--- a/src/integration_tests/doppler/syslog_drain_binding_test.go
+++ b/src/integration_tests/doppler/syslog_drain_binding_test.go
@@ -206,12 +206,17 @@ var _ = Describe("Syslog Drain Binding", func() {
 			Eventually(func() *gbytes.Buffer {
 				SendAppLog(appID, "overflow2", inputConnection)
 				return dopplerSession.Out
-			}, 20, 1).Should(gbytes.Say(`TB: Output channel too full`))
+			}, 50, 0.5).Should(gbytes.Say(`TB: Output channel too full`))
 
 			Eventually(func() *gbytes.Buffer {
 				SendAppLog(appID, "overflow2", inputConnection)
 				return dopplerSession.Out
-			}, 20, 1).Should(gbytes.Say(`TB: Output channel too full`))
+			}, 50, 0.5).Should(gbytes.Say(`TB: Output channel too full`))
+
+			Eventually(func() *gbytes.Buffer {
+				SendAppLog(appID, "overflow2", inputConnection)
+				return dopplerSession.Out
+			}, 50, 0.5).Should(gbytes.Say(`TB: Output channel too full`))
 
 			By("starting the endpoint (2nd time)")
 			serverSession = StartHTTPSServer(pathToHTTPEchoServer)


### PR DESCRIPTION
Fixes a race condition in Doppler as described in #105.

It replaces the current `TruncatingBuffer` logic of swapping the output channel with an implementation that drains the channel when blocked. This fixes the race condition, improves readability, and avoids some unnecessary `sync.Mutex` usage.
