### PR TITLE
Add a switch to control setting ulimit

### DIFF
--- a/jobs/doppler/spec
+++ b/jobs/doppler/spec
@@ -83,6 +83,10 @@ properties:
     description: "When connecting over TLS, don't verify certificates for syslog sink"
     default: true
 
+  doppler.locked_memory_limit:
+    description: "Size (KB) of shell's locked memory limit. Set to -1 to use the kernel's default."
+    default: "unlimited"
+
   loggregator.etcd.machines:
     description: "IPs pointing to the ETCD cluster"
 

--- a/jobs/doppler/templates/doppler_ctl.erb
+++ b/jobs/doppler/templates/doppler_ctl.erb
@@ -14,7 +14,9 @@ case $1 in
     mkdir -p $RUN_DIR
     mkdir -p $LOG_DIR
 
-    ulimit -l unlimited
+    <% if p("doppler.locked_memory_limit") != -1 %>
+    ulimit -l <%= p("doppler.locked_memory_limit") %>
+    <% end %>
     ulimit -n 65536
 
     <% p("doppler.debug") == true ? debug_string = "--debug " : debug_string = "" %>

--- a/jobs/loggregator_trafficcontroller/spec
+++ b/jobs/loggregator_trafficcontroller/spec
@@ -16,6 +16,9 @@ properties:
   traffic_controller.disable_access_control:
     description: "Traffic controller bypasses authentication with the UAA and CC"
     default: false
+  traffic_controller.locked_memory_limit:
+    description: "Size (KB) of shell's locked memory limit. Set to -1 to use the kernel's default."
+    default: "unlimited"
   loggregator.outgoing_dropsonde_port:
     description: "Port for outgoing dropsonde messages"
     default: 8081

--- a/jobs/loggregator_trafficcontroller/templates/loggregator_trafficcontroller_ctl.erb
+++ b/jobs/loggregator_trafficcontroller/templates/loggregator_trafficcontroller_ctl.erb
@@ -14,7 +14,9 @@ case $1 in
     mkdir -p $RUN_DIR
     mkdir -p $LOG_DIR
 
-    ulimit -l unlimited
+    <% if p("traffic_controller.locked_memory_limit") != -1 %>
+    ulimit -l <%= p("traffic_controller.locked_memory_limit") %>
+    <% end %>
     ulimit -n 65536
 
     <% p("traffic_controller.debug") == true ? debug_string = "--debug " : debug_string = "" %>

--- a/jobs/syslog_drain_binder/spec
+++ b/jobs/syslog_drain_binder/spec
@@ -36,6 +36,9 @@ properties:
   syslog_drain_binder.debug:
     description: boolean value to turn on verbose logging for syslog_drain_binder
     default: false
+  syslog_drain_binder.locked_memory_limit:
+    description: "Size (KB) of shell's locked memory limit. Set to -1 to use the kernel's default."
+    default: "unlimited"
 
   cc.bulk_api_password:
     description: "password for the bulk api"

--- a/jobs/syslog_drain_binder/templates/syslog_drain_binder_ctl.erb
+++ b/jobs/syslog_drain_binder/templates/syslog_drain_binder_ctl.erb
@@ -14,7 +14,9 @@ case $1 in
     mkdir -p $RUN_DIR
     mkdir -p $LOG_DIR
 
-    ulimit -l unlimited
+    <% if p("syslog_drain_binder.locked_memory_limit") != -1 %>
+    ulimit -l <%= p("syslog_drain_binder.locked_memory_limit") %>
+    <% end %>
     ulimit -n 65536
 
     <% p("syslog_drain_binder.debug") == true ? debug_string = "--debug " : debug_string = "" %>


### PR DESCRIPTION
Not all environments allow changing locked memory via `ulimit -l`, allow these to be controlled via config setting.