### PR TITLE
Fix panics on initialization in metron

### DIFF
--- a/src/metron/main.go
+++ b/src/metron/main.go
@@ -55,6 +55,9 @@ func main() {
 	// the os.Exit call.
 	exitCode := 0
 	defer func() {
+		if e := recover(); e != nil {
+			panic(e)
+		}
 		os.Exit(exitCode)
 	}()
 


### PR DESCRIPTION
deferreds still happen when panicking, and calling os.Exit in the defer means that the panic error will never get printed.

I believe other mains in this project have this same pattern, should probably fix it elsewhere too.