### PR TITLE
Don't panic when syslog is provided on Windows

### DIFF
--- a/src/logger/logging_windows.go
+++ b/src/logger/logging_windows.go
@@ -6,7 +6,13 @@ import (
 	"github.com/cloudfoundry/gosteno"
 )
 
+type FakeSink struct{}
+
+func (f FakeSink) AddRecord(r *gosteno.Record)  {}
+func (f FakeSink) Flush()                       {}
+func (f FakeSink) SetCodec(codec gosteno.Codec) {}
+func (f FakeSink) GetCodec() gosteno.Codec      { return nil }
+
 func GetNewSyslogSink(namespace string) gosteno.Sink {
-	panic("Syslog is not supported on windows")
-	return nil
+	return FakeSink{}
 }


### PR DESCRIPTION
With Bosh Windows soon becoming a reality, Windows VMs will get the same syslog properties as Linux ones, since they're generally defined as global properties in the manifest.

This change makes it so the syslog sink for Windows is just a no-op instead of panicking. This allows us to share the same `metron_agent.json.erb` job template, rather than having to maintain a copy that removes the syslog property.