### PR TITLE
Set the status code according to the failure

### DIFF
--- a/src/trafficcontroller/authorization/log_access_authorizer.go
+++ b/src/trafficcontroller/authorization/log_access_authorizer.go
@@ -12,10 +12,10 @@ const (
 	INVALID_AUTH_TOKEN_ERROR_MESSAGE     = "Error: Invalid authorization"
 )
 
-type LogAccessAuthorizer func(authToken string, appId string, logger *gosteno.Logger) (bool, error)
+type LogAccessAuthorizer func(authToken string, appId string, logger *gosteno.Logger) (int, error)
 
-func disableLogAccessControlAuthorizer(_, _ string, _ *gosteno.Logger) (bool, error) {
-	return true, nil
+func disableLogAccessControlAuthorizer(_, _ string, _ *gosteno.Logger) (int, error) {
+	return http.StatusOK, nil
 }
 
 func NewLogAccessAuthorizer(disableAccessControl bool, apiHost string) LogAccessAuthorizer {
@@ -24,9 +24,10 @@ func NewLogAccessAuthorizer(disableAccessControl bool, apiHost string) LogAccess
 		return LogAccessAuthorizer(disableLogAccessControlAuthorizer)
 	}
 
-	isAccessAllowed := func(authToken string, target string, logger *gosteno.Logger) (bool, error) {
+	isAccessAllowed := func(authToken string, target string, logger *gosteno.Logger) (int, error) {
 		if authToken == "" {
-			return false, errors.New(NO_AUTH_TOKEN_PROVIDED_ERROR_MESSAGE)
+			logger.Errorf(NO_AUTH_TOKEN_PROVIDED_ERROR_MESSAGE)
+			return http.StatusUnauthorized, errors.New(NO_AUTH_TOKEN_PROVIDED_ERROR_MESSAGE)
 		}
 
 		req, _ := http.NewRequest("GET", apiHost+"/internal/log_access/"+target, nil)
@@ -34,16 +35,18 @@ func NewLogAccessAuthorizer(disableAccessControl bool, apiHost string) LogAccess
 		res, err := http.DefaultClient.Do(req)
 		if err != nil {
 			logger.Errorf("Could not get app information: [%s]", err)
-			return false, errors.New(INVALID_AUTH_TOKEN_ERROR_MESSAGE)
+			return http.StatusInternalServerError, err
 		}
 
 		defer res.Body.Close()
 
+		err = nil
 		if res.StatusCode != 200 {
-			logger.Warnf("Non 200 response from CC API: %d", res.StatusCode)
-			return false, errors.New(INVALID_AUTH_TOKEN_ERROR_MESSAGE)
+			logger.Warnf("Non 200 response from CC API: %d for %s", res.StatusCode, target)
+			err = errors.New(http.StatusText(res.StatusCode))
 		}
-		return true, nil
+
+		return res.StatusCode, err
 	}
 
 	return LogAccessAuthorizer(isAccessAllowed)

--- a/src/trafficcontroller/dopplerproxy/dopplerproxy_suite_test.go
+++ b/src/trafficcontroller/dopplerproxy/dopplerproxy_suite_test.go
@@ -2,10 +2,12 @@ package dopplerproxy_test
 
 import (
 	"errors"
+	"net/http"
+	"testing"
+
 	"github.com/cloudfoundry/gosteno"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"testing"
 )
 
 func TestDopplerProxy(t *testing.T) {
@@ -14,7 +16,7 @@ func TestDopplerProxy(t *testing.T) {
 }
 
 type AuthorizerResult struct {
-	Authorized   bool
+	Status       int
 	ErrorMessage string
 }
 
@@ -24,11 +26,11 @@ type LogAuthorizer struct {
 	Result     AuthorizerResult
 }
 
-func (a *LogAuthorizer) Authorize(authToken string, target string, l *gosteno.Logger) (bool, error) {
+func (a *LogAuthorizer) Authorize(authToken string, target string, l *gosteno.Logger) (int, error) {
 	a.TokenParam = authToken
 	a.Target = target
 
-	return a.Result.Authorized, errors.New(a.Result.ErrorMessage)
+	return a.Result.Status, errors.New(a.Result.ErrorMessage)
 }
 
 type AdminAuthorizer struct {
@@ -39,5 +41,5 @@ type AdminAuthorizer struct {
 func (a *AdminAuthorizer) Authorize(authToken string, l *gosteno.Logger) (bool, error) {
 	a.TokenParam = authToken
 
-	return a.Result.Authorized, errors.New(a.Result.ErrorMessage)
+	return a.Result.Status == http.StatusOK, errors.New(a.Result.ErrorMessage)
 }


### PR DESCRIPTION
This solves the issue reported by #130 

The log access authorizer in CC returns 200, 401, 403, 404 and 500.
Reflect the actual status of the request except for 403 which should be
treated as a 404.

The main importance is to determine the difference between an actual 401 which
requires a refresh of the token or a 404 when the app is not
present/forbidden.