### PR TITLE
Small cleanups

### DIFF
--- a/src/doppler/main.go
+++ b/src/doppler/main.go
@@ -7,7 +7,6 @@ import (
 	"net"
 	"net/http"
 	_ "net/http/pprof"
-	"runtime"
 	"time"
 
 	"doppler/config"
@@ -72,16 +71,14 @@ func main() {
 
 	flag.Parse()
 
-	runtime.GOMAXPROCS(runtime.NumCPU())
-
 	localIp, err := localip.LocalIP()
 	if err != nil {
-		panic(fmt.Errorf("Unable to resolve own IP address: %s", err))
+		fatal("Unable to resolve own IP address: %s", err)
 	}
 
 	conf, err := config.ParseConfig(*configFile)
 	if err != nil {
-		panic(fmt.Errorf("Unable to parse config: %s", err))
+		fatal("Unable to parse config: %s", err)
 	}
 
 	log := logger.NewLogger(*logLevel, *logFilePath, "doppler", conf.Syslog)
@@ -100,7 +97,7 @@ func main() {
 	doppler, err := New(log, localIp, conf, storeAdapter, conf.MessageDrainBufferSize, DOPPLER_ORIGIN, time.Duration(conf.WebsocketWriteTimeoutSeconds)*time.Second, time.Duration(conf.SinkDialTimeoutSeconds)*time.Second)
 
 	if err != nil {
-		panic(fmt.Errorf("Failed to create doppler: %s", err))
+		fatal("Failed to create doppler: %s", err)
 	}
 
 	go doppler.Start()
@@ -132,4 +129,8 @@ func main() {
 			return
 		}
 	}
+}
+
+func fatal(format string, args ...interface{}) {
+	panic(fmt.Sprintf(format, args...))
 }


### PR DESCRIPTION
Two small cleanups

- Remove `runtime.GOMAXPROCS` call in func main. Since Go 1.5, GOMAXPROCS
  now defaults to runtime.NumCPU, so this call is redundant.
- Add `fatal` helper function and use it in a few places in func main.