### PR TITLE
Make metron agent's bind address configurable

### DIFF
--- a/jobs/metron_agent/spec
+++ b/jobs/metron_agent/spec
@@ -53,7 +53,7 @@ properties:
     description: "Port the metron agent is listening on to receive dropsonde log messages"
     default: 3457
   metron_agent.listening_address:
-    description: "Address the metron agent is listening on to receive dropsonde log messages provided for BOSH links and should not be overwritten"
+    description: "Address the metron agent is listening on to receive dropsonde log messages provided for BOSH links"
     default: "127.0.0.1"
   metron_agent.debug:
     description: "boolean value to turn on verbose mode"

--- a/jobs/metron_agent/templates/metron_agent.json.erb
+++ b/jobs/metron_agent/templates/metron_agent.json.erb
@@ -55,6 +55,7 @@
   "SharedSecret": "<%= p("metron_endpoint.shared_secret")  %>",
 
   "IncomingUDPPort": <%= incoming_udp_port %>,
+  "ListeningAddress": "<%= p("metron_agent.listening_address") %>",
 
   "Protocols": <%= protocols %>,
 

--- a/jobs/metron_agent_windows/templates/metron_agent.json.erb
+++ b/jobs/metron_agent_windows/templates/metron_agent.json.erb
@@ -55,6 +55,7 @@
   "SharedSecret": "<%= p("metron_endpoint.shared_secret")  %>",
 
   "IncomingUDPPort": <%= incoming_udp_port %>,
+  "ListeningAddress": "<%= p("metron_agent.listening_address") %>",
 
   "Protocols": <%= protocols %>,
 

--- a/src/metron/config/config.go
+++ b/src/metron/config/config.go
@@ -58,7 +58,8 @@ type Config struct {
 	Job        string
 	Index      string
 
-	IncomingUDPPort int
+	IncomingUDPPort  int
+	ListeningAddress string
 
 	EtcdUrls                      []string
 	EtcdMaxConcurrentRequests     int
@@ -99,6 +100,7 @@ func Parse(reader io.Reader) (*Config, error) {
 		MetricBatchIntervalMilliseconds:  5000,
 		RuntimeStatsIntervalMilliseconds: 15000,
 		Protocols:                        []Protocol{"udp"},
+		ListeningAddress:                 "127.0.0.1",
 	}
 	err := json.NewDecoder(reader).Decode(config)
 	if err != nil {

--- a/src/metron/config/config_test.go
+++ b/src/metron/config/config_test.go
@@ -47,6 +47,7 @@ var _ = Describe("Config", func() {
 				Expect(cfg.SharedSecret).To(Equal("shared_secret"))
 
 				Expect(cfg.IncomingUDPPort).To(Equal(51161))
+				Expect(cfg.ListeningAddress).To(Equal("1.3.3.7"))
 
 				Expect(cfg.MetricBatchIntervalMilliseconds).To(BeEquivalentTo(20))
 				Expect(cfg.RuntimeStatsIntervalMilliseconds).To(BeEquivalentTo(15))
@@ -85,6 +86,7 @@ var _ = Describe("Config", func() {
 					MetricBatchIntervalMilliseconds:  5000,
 					RuntimeStatsIntervalMilliseconds: 15000,
 					Protocols:                        []config.Protocol{"udp"},
+					ListeningAddress:                 "127.0.0.1",
 				}))
 			})
 

--- a/src/metron/config/fixtures/metron.json
+++ b/src/metron/config/fixtures/metron.json
@@ -11,6 +11,7 @@
   "SharedSecret": "shared_secret",
 
   "IncomingUDPPort": 51161,
+  "ListeningAddress": "1.3.3.7",
   "LoggregatorDropsondePort": 3457,
   "Syslog": "syslog.namespace",
   "MetricBatchIntervalMilliseconds": 20,

--- a/src/metron/main.go
+++ b/src/metron/main.go
@@ -84,7 +84,7 @@ func main() {
 	eventWriter.SetWriter(aggregator)
 
 	dropsondeUnmarshaller := eventunmarshaller.New(aggregator, batcher, logger)
-	metronAddress := fmt.Sprintf("127.0.0.1:%d", config.IncomingUDPPort)
+	metronAddress := fmt.Sprintf("%s:%d", config.ListeningAddress, config.IncomingUDPPort)
 	dropsondeReader, err := networkreader.New(metronAddress, "dropsondeAgentListener", dropsondeUnmarshaller, logger)
 	if err != nil {
 		panic(fmt.Errorf("Failed to listen on %s: %s", metronAddress, err))


### PR DESCRIPTION
This allows the metron agent's listen address to be configurable through the `metron_agent` bosh job.