### PR TITLE
Implement logic to send service logs to syslog

### DIFF
--- a/jobs/doppler/spec
+++ b/jobs/doppler/spec
@@ -101,6 +101,10 @@ properties:
     description: "Size (KB) of shell's locked memory limit. Set to 'kernel' to use the kernel's default. Non-numeric values other than 'kernel', 'soft', 'hard', and 'unlimited' will result in an error."
     default: "unlimited"
 
+  doppler.log_to_syslog:
+    description: "Set this to True to enable logging to syslog."
+    default: False
+
   loggregator.etcd.machines:
     description: "IPs pointing to the ETCD cluster"
 

--- a/jobs/doppler/templates/doppler_ctl.erb
+++ b/jobs/doppler/templates/doppler_ctl.erb
@@ -32,7 +32,7 @@ case $1 in
     <% p("doppler.debug") == true ? debug_string = "--debug " : debug_string = "" %>
 
     <% if p('doppler.log_to_syslog') %>
-    tee_output_to_sys_log "$LOG_DIR" doppler
+    tee_output_to_sys_log "$LOG_DIR" doppler stdout stderr
     <% else %>
     exec >>$LOG_DIR/doppler.stdout.log  \
        2>>$LOG_DIR/doppler.stderr.log

--- a/jobs/doppler/templates/doppler_ctl.erb
+++ b/jobs/doppler/templates/doppler_ctl.erb
@@ -31,8 +31,12 @@ case $1 in
 
     <% p("doppler.debug") == true ? debug_string = "--debug " : debug_string = "" %>
 
+    <% if p('doppler.log_to_syslog') %>
+    tee_output_to_sys_log "$LOG_DIR" doppler
+    <% else %>
     exec >>$LOG_DIR/doppler.stdout.log  \
        2>>$LOG_DIR/doppler.stderr.log
+    <% end %>
 
     chown -R vcap:vcap $LOG_DIR
 

--- a/jobs/metron_agent/spec
+++ b/jobs/metron_agent/spec
@@ -121,3 +121,7 @@ properties:
   metron_agent.preferred_protocol:
     description: "DEPRECATED - replaced with metron_agent.protocols"
     default: "udp"
+
+  metron_agent.log_to_syslog:
+    description: "Set this to True to enable logging to syslog."
+    default: False

--- a/jobs/metron_agent/templates/metron_agent_ctl.erb
+++ b/jobs/metron_agent/templates/metron_agent_ctl.erb
@@ -24,7 +24,7 @@ case $1 in
     <% end %>
 
     <% if p('metron_agent.log_to_syslog') %>
-    tee_output_to_sys_log "$LOG_DIR" metron_agent
+    tee_output_to_sys_log "$LOG_DIR" metron_agent stdout stderr
     <% else %>
     exec >>$LOG_DIR/metron_agent.stdout.log \
         2>>$LOG_DIR/metron_agent.stderr.log

--- a/jobs/metron_agent/templates/metron_agent_ctl.erb
+++ b/jobs/metron_agent/templates/metron_agent_ctl.erb
@@ -23,8 +23,12 @@ case $1 in
     /var/vcap/packages/metron_agent/syslog_daemon_config/setup_syslog_forwarder.sh /var/vcap/jobs/metron_agent/config
     <% end %>
 
+    <% if p('metron_agent.log_to_syslog') %>
+    tee_output_to_sys_log "$LOG_DIR" metron_agent
+    <% else %>
     exec >>$LOG_DIR/metron_agent.stdout.log \
         2>>$LOG_DIR/metron_agent.stderr.log
+    <% end %>
 
     chown -R vcap:vcap $LOG_DIR
 

--- a/jobs/statsd-injector/spec
+++ b/jobs/statsd-injector/spec
@@ -16,3 +16,6 @@ properties:
   statsd_injector.log_level:
     description: "The log level for the statsd injector"
     default: "info"
+  statsd_injector.log_to_syslog:
+    description: "Set this to True to enable logging to syslog."
+    default: False

--- a/jobs/statsd-injector/templates/statsd-injector-ctl.erb
+++ b/jobs/statsd-injector/templates/statsd-injector-ctl.erb
@@ -18,7 +18,7 @@ case $1 in
     pid_guard $PIDFILE "Statsd Injector"
 
     <% if p('statsd_injector.log_to_syslog') %>
-    tee_output_to_sys_log "$LOG_DIR" statsd_injector
+    tee_output_to_sys_log "$LOG_DIR" statsd_injector stdout stderr
     <% else %>
     exec >>$LOG_DIR/statsd_injector.stdout.log \
         2>>$LOG_DIR/statsd_injector.stderr.log

--- a/jobs/statsd-injector/templates/statsd-injector-ctl.erb
+++ b/jobs/statsd-injector/templates/statsd-injector-ctl.erb
@@ -17,8 +17,12 @@ case $1 in
   start)
     pid_guard $PIDFILE "Statsd Injector"
 
+    <% if p('statsd_injector.log_to_syslog') %>
+    tee_output_to_sys_log "$LOG_DIR" statsd_injector
+    <% else %>
     exec >>$LOG_DIR/statsd_injector.stdout.log \
         2>>$LOG_DIR/statsd_injector.stderr.log
+    <% end %>
 
     chown -R vcap:vcap $LOG_DIR
 

--- a/jobs/syslog_drain_binder/spec
+++ b/jobs/syslog_drain_binder/spec
@@ -56,6 +56,10 @@ properties:
     description: "Size (KB) of shell's locked memory limit. Set to 'kernel' to use the kernel's default. Non-numeric values other than 'kernel', 'soft', 'hard', and 'unlimited' will result in an error."
     default: "unlimited"
 
+  syslog_drain_binder.log_to_syslog:
+    description: "Set this to True to enable logging to syslog."
+    default: False
+
   cc.bulk_api_password:
     description: "Password for the bulk api"
   cc.srv_api_uri:

--- a/jobs/syslog_drain_binder/templates/syslog_drain_binder_ctl.erb
+++ b/jobs/syslog_drain_binder/templates/syslog_drain_binder_ctl.erb
@@ -31,8 +31,12 @@ case $1 in
 
     <% p("syslog_drain_binder.debug") == true ? debug_string = "--debug " : debug_string = "" %>
 
+    <% if p('syslog_drain_binder.log_to_syslog') %>
+    tee_output_to_sys_log "$LOG_DIR" syslog_drain_binder
+    <% else %>
     exec >>$LOG_DIR/syslog_drain_binder.stdout.log \
          2>>$LOG_DIR/syslog_drain_binder.stderr.log
+    <% end %>
 
     chown -R vcap:vcap $LOG_DIR
 

--- a/jobs/syslog_drain_binder/templates/syslog_drain_binder_ctl.erb
+++ b/jobs/syslog_drain_binder/templates/syslog_drain_binder_ctl.erb
@@ -32,7 +32,7 @@ case $1 in
     <% p("syslog_drain_binder.debug") == true ? debug_string = "--debug " : debug_string = "" %>
 
     <% if p('syslog_drain_binder.log_to_syslog') %>
-    tee_output_to_sys_log "$LOG_DIR" syslog_drain_binder
+    tee_output_to_sys_log "$LOG_DIR" syslog_drain_binder stdout stderr
     <% else %>
     exec >>$LOG_DIR/syslog_drain_binder.stdout.log \
          2>>$LOG_DIR/syslog_drain_binder.stderr.log

--- a/src/common/syslog_utils.sh
+++ b/src/common/syslog_utils.sh
@@ -2,9 +2,15 @@
 # tee_output_to_sys_log
 #
 # When syslog_utils.sh is loaded, this sends stdout and stderr to /var/vcap/sys/log.
+#
+# Params:
+#  - $1 logdir: directory to write the log files
+#  - $2 log_basename: optional, basename for the syslog tag and log file
+#  - $3 stdout_suffix: suffix for stdout log file
+#  - $4 stderr_suffix: suffix for stderr log file
 function tee_output_to_sys_log() {
   declare log_dir="$1"
-
+  shift
   if [ "$log_dir" = "" ] ; then
     return 1
   fi
@@ -13,13 +19,19 @@ function tee_output_to_sys_log() {
     return 2
   fi
 
-  declare log_basename="$2"
-  if [ "$log_basename" = "" ] ; then
-    log_basename="$(basename "$0")"
-  fi
+  declare log_basename="${1:-$(basename "$0")}"
+  shift
 
-  exec > >(tee -a >(logger -p user.info -t "vcap.${log_basename}.stdout") | prepend_datetime >>"${log_dir}/${log_basename}.log")
-  exec 2> >(tee -a >(logger -p user.error -t "vcap.${log_basename}.stderr") | prepend_datetime >>"${log_dir}/${log_basename}.err.log")
+  declare stdout_suffix="${1:-}"
+  stdout_suffix="${stdout_suffix:+.${stdout_suffix}}"
+  shift
+
+  declare stderr_suffix="${1:-err}"
+  stderr_suffix="${stderr_suffix:+.${stderr_suffix}}"
+  shift
+
+  exec > >(tee -a >(logger -p user.info -t "vcap.${log_basename}.stdout") | prepend_datetime >>"${log_dir}/${log_basename}${stdout_suffix}.log")
+  exec 2> >(tee -a >(logger -p user.error -t "vcap.${log_basename}.stderr") | prepend_datetime >>"${log_dir}/${log_basename}${stderr_suffix}.log")
 }
 
 function prepend_datetime() {

--- a/src/common/syslog_utils.sh
+++ b/src/common/syslog_utils.sh
@@ -13,8 +13,10 @@ function tee_output_to_sys_log() {
     return 2
   fi
 
-  local log_basename
-  log_basename="$(basename "$0")"
+  declare log_basename="$2"
+  if [ "$log_basename" = "" ] ; then
+    log_basename="$(basename "$0")"
+  fi
 
   exec > >(tee -a >(logger -p user.info -t "vcap.${log_basename}.stdout") | prepend_datetime >>"${log_dir}/${log_basename}.log")
   exec 2> >(tee -a >(logger -p user.error -t "vcap.${log_basename}.stderr") | prepend_datetime >>"${log_dir}/${log_basename}.err.log")

--- a/src/common/syslog_utils_test.bats
+++ b/src/common/syslog_utils_test.bats
@@ -15,11 +15,18 @@ setup() {
 
 @test "tee_output_to_sys_log should create the correct logfile when defining log_basename" {
   run tee_output_to_sys_log ${TMPDIR} "foo"
+  ls $TMPDIR
   [ "$status" -eq 0 ]
   [ -e "${TMPDIR}/foo.log" ]
   [ -e "${TMPDIR}/foo.err.log" ]
 }
 
+@test "tee_output_to_sys_log should create the correct logfile when defining log_basename and stdout/stderr suffix" {
+  run tee_output_to_sys_log ${TMPDIR} "foo" "stdout" "stderr"
+  [ "$status" -eq 0 ]
+  [ -e "${TMPDIR}/foo.stdout.log" ]
+  [ -e "${TMPDIR}/foo.stderr.log" ]
+}
 
 @test "tee_output_to_sys_log requires non empty log_dir" {
   run tee_output_to_sys_log

--- a/src/common/syslog_utils_test.bats
+++ b/src/common/syslog_utils_test.bats
@@ -3,7 +3,7 @@
 setup() {
   source ./syslog_utils.sh
 
-  TMPDIR=$(mktemp -dt "syslog_util")
+  TMPDIR=$(mktemp -dt "syslog_util_XXX")
 }
 
 @test "tee_output_to_sys_log should create the correct logfile" {

--- a/src/common/syslog_utils_test.bats
+++ b/src/common/syslog_utils_test.bats
@@ -6,12 +6,20 @@ setup() {
   TMPDIR=$(mktemp -dt "syslog_util_XXX")
 }
 
-@test "tee_output_to_sys_log should create the correct logfile" {
+@test "tee_output_to_sys_log should create the correct logfile when not defining log_basename" {
   run tee_output_to_sys_log ${TMPDIR}
   [ "$status" -eq 0 ]
   [ -e "${TMPDIR}/bats-exec-test.log" ]
   [ -e "${TMPDIR}/bats-exec-test.err.log" ]
 }
+
+@test "tee_output_to_sys_log should create the correct logfile when defining log_basename" {
+  run tee_output_to_sys_log ${TMPDIR} "foo"
+  [ "$status" -eq 0 ]
+  [ -e "${TMPDIR}/foo.log" ]
+  [ -e "${TMPDIR}/foo.err.log" ]
+}
+
 
 @test "tee_output_to_sys_log requires non empty log_dir" {
   run tee_output_to_sys_log


### PR DESCRIPTION
# Motivation

Several of the CF and Diego platform services send logs to the local syslog, tagged as `vcap.*`. . The [metron agent from loggregrator configures the local syslog to send the logs to metron](https://github.com/cloudfoundry/loggregator/blob/develop/jobs/metron_agent/spec#L29) so that later can be sent to a centralised logging service. 

In some cases it is the service application itself who sends the logs to syslog, but it seems to be a common pattern across CF and Diego services to [let the service log to stdout/stderr, and redirect that output to local files or syslog](https://github.com/cloudfoundry/diego-release/blob/develop/jobs/bbs/templates/bbs_as_vcap.erb#L91) using the [`logger` command](http://linux.die.net/man/1/logger). 

Not all the services implement this feature, and instead they only log to local files. In order to centralise all the logs, so we will add the logic required to send the logs of the missing services. 

We will implement the _log to stdout and redirect  to `logger` pattern_ whenever is possible.
## Implementation in loggregator release

We add a property for each service `*.log_to_syslog` to allow enable the feature in each service.

We reuse the helper function `tee_output_to_sys_log()`, but extending it to allow define a custom service name and stdout/stderr prefixes for the log files.
## How to review?

Enable the `*.log_to_syslog` and deploy. Logs should be sent to syslog. If metron agent is installed locally, the logs will be redirected to metron agent the loggregrator.
## Open questions

This PR is open to debate for several open questions:
- Is OK to add a specific property to enable each service logs to syslog? or should this be enabled by default?
- Are the tags right? 
- shall we simplify the helper function and not allow override the stdout/stderr suffixes?
