### PR TITLE
Use modern syntax to configure rsyslog targets and allow configure action parameters

### DIFF
--- a/jobs/metron_agent/spec
+++ b/jobs/metron_agent/spec
@@ -36,6 +36,9 @@ properties:
   syslog_daemon_config.transport:
     description: "Transport to be used when forwarding logs (tcp|udp|relp)."
     default: "tcp"
+  syslog_daemon_config.rsyslog_action_parameters:
+    description: "Hash of custom parameters for rsyslog action. See http://www.rsyslog.com/doc/v8-stable/configuration/actions.html#general-action-parameters"
+    default: {}
   syslog_daemon_config.fallback_addresses:
     description: "Addresses of fallback servers to be used if the primary syslog server is down. Only tcp or relp are supported. Each list entry should consist of \"address\", \"transport\" and \"port\" keys. "
     default: []

--- a/jobs/metron_agent/templates/syslog_forwarder.conf.erb
+++ b/jobs/metron_agent/templates/syslog_forwarder.conf.erb
@@ -60,11 +60,22 @@ template(name="CfLogTemplate" type="list") {
 
 <% if transport == "relp" %>
 $ModLoad omrelp
-*.* :omrelp:<%= address %>:<%= port %>;CfLogTemplate
+action(type="omrelp"
+       target="<%= address %>"
+       port="<%= port %>"
+       template="CfLogTemplate")
 <% elsif transport == "udp" %>
-*.* @<%= address %>:<%= port %>;CfLogTemplate
+action(type="omfwd"
+       Protocol="udp"
+       Target="<%= address %>"
+       Port="<%= port %>"
+       template="CfLogTemplate")
 <% elsif transport == "tcp" %>
-*.* @@<%= address %>:<%= port %>;CfLogTemplate
+action(type="omfwd"
+       Protocol="tcp"
+       Target="<%= address %>"
+       Port="<%= port %>"
+       template="CfLogTemplate")
 <% else %>
 #only RELP, UDP, and TCP are supported
 <% end %>
@@ -80,9 +91,16 @@ $ActionExecOnlyWhenPreviousIsSuspended on
    port = fallback_address["port"]
 %>
 <% if transport == "relp" %>
-& :omrelp:<%= address %>:<%= port %>;CfLogTemplate
+action(type="omrelp"
+       target="<%= address %>"
+       port="<%= port %>"
+       template="CfLogTemplate")
 <% elsif transport == "tcp" %>
-& @@<%= address %>:<%= port %>;CfLogTemplate
+action(type="omfwd"
+       Protocol="tcp"
+       Target="<%= address %>"
+       Port="<%= port %>"
+       template="CfLogTemplate")
 <% else %>
 # only RELP and TCP are supported
 <% end %>

--- a/jobs/metron_agent/templates/syslog_forwarder.conf.erb
+++ b/jobs/metron_agent/templates/syslog_forwarder.conf.erb
@@ -21,6 +21,10 @@ $UDPServerRun 514
 
 
 <%
+   def rendered_action_parameters
+      return p("syslog_daemon_config.rsyslog_action_parameters").map{|k,v| "#{k}=\"#{v}\""}.join(' ')
+   end
+
    def discover_external_ip
      networks = spec.networks.marshal_dump
      _, network = networks.find do |_name, network_spec|
@@ -57,25 +61,27 @@ template(name="CfLogTemplate" type="list") {
 <%= p('syslog_daemon_config.custom_rule') %>
 
 <% if_p("syslog_daemon_config.address", "syslog_daemon_config.port", "syslog_daemon_config.transport") do |address, port, transport| %>
-
 <% if transport == "relp" %>
 $ModLoad omrelp
 action(type="omrelp"
        target="<%= address %>"
        port="<%= port %>"
-       template="CfLogTemplate")
+       template="CfLogTemplate"
+       <%= rendered_action_parameters() %>)
 <% elsif transport == "udp" %>
 action(type="omfwd"
        Protocol="udp"
        Target="<%= address %>"
        Port="<%= port %>"
-       template="CfLogTemplate")
+       template="CfLogTemplate"
+       <%= rendered_action_parameters() %>)
 <% elsif transport == "tcp" %>
 action(type="omfwd"
        Protocol="tcp"
        Target="<%= address %>"
        Port="<%= port %>"
-       template="CfLogTemplate")
+       template="CfLogTemplate"
+       <%= rendered_action_parameters() %>)
 <% else %>
 #only RELP, UDP, and TCP are supported
 <% end %>
@@ -94,13 +100,15 @@ $ActionExecOnlyWhenPreviousIsSuspended on
 action(type="omrelp"
        target="<%= address %>"
        port="<%= port %>"
-       template="CfLogTemplate")
+       template="CfLogTemplate"
+       <%= rendered_action_parameters() %>)
 <% elsif transport == "tcp" %>
 action(type="omfwd"
        Protocol="tcp"
        Target="<%= address %>"
        Port="<%= port %>"
-       template="CfLogTemplate")
+       template="CfLogTemplate"
+       <%= rendered_action_parameters() %>)
 <% else %>
 # only RELP and TCP are supported
 <% end %>


### PR DESCRIPTION
The syslog forwarder configuration for the omrepl and omfwd modules uses the old configuration syntax.

We want to update it to the new syntax for several reasons:

 - in order to be able to configure additional settings, like `timeout` for `omrepl`[3], we need to convert it to the new syntax.

 - We are experiencing a issue when the RELP syslog server is behind an AWS ELB loadbalancer in TCP mode with healthchecks. When all the backends are down in the ELB, it will open the TCP connection and    close it immediately. When that happens, rsyslog using omrelp with the old syntax does not exit when receiving a TERM signal.

   This causes the `service rsyslogd restart` executed from metron_agent ctl take 30 seconds, and the job metron_agent is marked as bad by monit.

 - It makes sense to use the new syntax

Then, we allow configure action parameters for rsyslog actions[1][2][3]

This would allow you to configure parameters like relp timeout, queue name, sizes, retries, etc. For example, it would make easier to configure forwarding to a rsyslog server behind a AWS ELB[4]

[1] http://www.rsyslog.com/doc/v8-stable/configuration/actions.html#general-action-parameters
[2] http://www.rsyslog.com/doc/v8-stable/configuration/modules/omfwd.html
[3] http://www.rsyslog.com/doc/v8-stable/configuration/modules/omrelp.html
[4] http://lists.adiscon.net/pipermail/rsyslog/2014-December/039270.html