### PR TITLE
Enables forwarding container metrics to syslog drain

### DIFF
--- a/jobs/doppler/spec
+++ b/jobs/doppler/spec
@@ -45,6 +45,9 @@ properties:
   doppler.tls.server_key:
     description: "TLS server key"
     default: ""
+  doppler.forward_container_metrics_to_syslog:
+    description: "Enables forwarding container metrics to syslog drain"
+    default: false
   loggregator.tls.ca_cert:
     description: "CA root required for key/cert verification"
     default: ""

--- a/jobs/doppler/templates/doppler.json.erb
+++ b/jobs/doppler/templates/doppler.json.erb
@@ -39,6 +39,7 @@
         a[:MessageDrainBufferSize] = p("doppler.message_drain_buffer_size")
         a[:IncomingUDPPort] = p("doppler.dropsonde_incoming_port")
         a[:IncomingTCPPort] = p("doppler.incoming_tcp_port")
+        a[:ForwardContainerMetricsToSysLog] = p("doppler.forward_container_metrics_to_syslog")
         if_p("doppler.tls.enable") do |_|
             a[:TLSListenerConfig] = tlsListenerConfig
         end

--- a/src/doppler/config/config.go
+++ b/src/doppler/config/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	ContainerMetricTTLSeconds       int
 	IncomingUDPPort                 uint32
 	IncomingTCPPort                 uint32
+	ForwardContainerMetricsToSysLog  bool
 	EnableTLSTransport              bool
 	TLSListenerConfig               TLSListenerConfig
 	EtcdMaxConcurrentRequests       int

--- a/src/doppler/doppler.go
+++ b/src/doppler/doppler.go
@@ -129,6 +129,7 @@ func New(
 		sinkIOTimeout,
 		metricTTL,
 		dialTimeout,
+		config.ForwardContainerMetricsToSysLog,
 	)
 
 	grpcRouter := grpcmanager.NewRouter()

--- a/src/doppler/groupedsinks/grouped_sinks_test.go
+++ b/src/doppler/groupedsinks/grouped_sinks_test.go
@@ -36,7 +36,7 @@ var _ = Describe("GroupedSink", func() {
 				groupedSinks.RegisterFirehoseSink(firehoseSinkChan, firehoseSink)
 
 				groupedSinks.CloseAndDeleteFirehose(firehoseSink)
-				appSink := syslog.NewSyslogSink("123", &url.URL{Host: "url"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin")
+				appSink := syslog.NewSyslogSink("123", &url.URL{Host: "url"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin", false)
 				appSinkInputChan := make(chan *events.Envelope)
 				groupedSinks.RegisterAppSink(appSinkInputChan, appSink)
 
@@ -49,13 +49,13 @@ var _ = Describe("GroupedSink", func() {
 
 		It("sends message to all registered sinks that match the appId", func(done Done) {
 			appId := "123"
-			appSink := syslog.NewSyslogSink("123", &url.URL{Host: "url"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin")
+			appSink := syslog.NewSyslogSink("123", &url.URL{Host: "url"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin", false)
 
 			otherInputChan := make(chan *events.Envelope)
 			groupedSinks.RegisterAppSink(otherInputChan, appSink)
 
 			appId = "789"
-			appSink = syslog.NewSyslogSink(appId, &url.URL{Host: "url"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin")
+			appSink = syslog.NewSyslogSink(appId, &url.URL{Host: "url"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin", false)
 
 			groupedSinks.RegisterAppSink(inputChan, appSink)
 
@@ -165,7 +165,7 @@ var _ = Describe("GroupedSink", func() {
 			appId := "789"
 
 			sink1 := dump.NewDumpSink(appId, 10, loggertesthelper.Logger(), time.Second)
-			sink2 := syslog.NewSyslogSink(appId, &url.URL{Host: "url"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin")
+			sink2 := syslog.NewSyslogSink(appId, &url.URL{Host: "url"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin", false)
 
 			groupedSinks.RegisterAppSink(inputChan, sink1)
 			groupedSinks.RegisterAppSink(inputChan, sink2)
@@ -180,21 +180,21 @@ var _ = Describe("GroupedSink", func() {
 	Describe("Register", func() {
 		It("returns false for empty app ids", func() {
 			appId := ""
-			appSink := syslog.NewSyslogSink(appId, &url.URL{Host: "url"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin")
+			appSink := syslog.NewSyslogSink(appId, &url.URL{Host: "url"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin", false)
 			result := groupedSinks.RegisterAppSink(inputChan, appSink)
 			Expect(result).To(BeFalse())
 		})
 
 		It("returns false for empty identifiers", func() {
 			appId := "appId"
-			appSink := syslog.NewSyslogSink(appId, &url.URL{Host: ""}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin")
+			appSink := syslog.NewSyslogSink(appId, &url.URL{Host: ""}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin", false)
 			result := groupedSinks.RegisterAppSink(inputChan, appSink)
 			Expect(result).To(BeFalse())
 		})
 
 		It("returns false when registering a duplicate", func() {
 			appId := "789"
-			appSink := syslog.NewSyslogSink(appId, &url.URL{Host: "url"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin")
+			appSink := syslog.NewSyslogSink(appId, &url.URL{Host: "url"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin", false)
 			groupedSinks.RegisterAppSink(inputChan, appSink)
 			result := groupedSinks.RegisterAppSink(inputChan, appSink)
 			Expect(result).To(BeFalse())
@@ -204,14 +204,14 @@ var _ = Describe("GroupedSink", func() {
 	Describe("RegisterFirehose", func() {
 		It("returns false for empty subscription ids", func() {
 			subscriptionId := ""
-			firehoseSink := syslog.NewSyslogSink(subscriptionId, &url.URL{Host: "url"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin")
+			firehoseSink := syslog.NewSyslogSink(subscriptionId, &url.URL{Host: "url"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin", false)
 			result := groupedSinks.RegisterFirehoseSink(inputChan, firehoseSink)
 			Expect(result).To(BeFalse())
 		})
 
 		It("returns true if a subscription id is present", func() {
 			subscriptionId := "firehose-subscription-a"
-			firehoseSink := syslog.NewSyslogSink(subscriptionId, &url.URL{Host: "url"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin")
+			firehoseSink := syslog.NewSyslogSink(subscriptionId, &url.URL{Host: "url"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin", false)
 			result := groupedSinks.RegisterFirehoseSink(inputChan, firehoseSink)
 			Expect(result).To(BeTrue())
 		})
@@ -221,8 +221,8 @@ var _ = Describe("GroupedSink", func() {
 		It("only deletes a specific sink", func() {
 			target := "789"
 
-			sink1 := syslog.NewSyslogSink(target, &url.URL{Host: "url1"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin")
-			sink2 := syslog.NewSyslogSink(target, &url.URL{Host: "url2"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin")
+			sink1 := syslog.NewSyslogSink(target, &url.URL{Host: "url1"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin", false)
+			sink2 := syslog.NewSyslogSink(target, &url.URL{Host: "url2"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin", false)
 
 			groupedSinks.RegisterAppSink(inputChan, sink1)
 			groupedSinks.RegisterAppSink(inputChan, sink2)
@@ -234,7 +234,7 @@ var _ = Describe("GroupedSink", func() {
 
 		It("handle deletes for non-existing appIds", func() {
 			target := "789"
-			sink1 := syslog.NewSyslogSink(target, &url.URL{Host: "url1"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin")
+			sink1 := syslog.NewSyslogSink(target, &url.URL{Host: "url1"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin", false)
 
 			ok := groupedSinks.CloseAndDelete(sink1)
 			Expect(ok).To(BeFalse())
@@ -245,8 +245,8 @@ var _ = Describe("GroupedSink", func() {
 		It("handle deletes for existing appIds but unregistered drain URLs", func() {
 			target := "789"
 
-			sink1 := syslog.NewSyslogSink(target, &url.URL{Host: "url1"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin")
-			sink2 := syslog.NewSyslogSink(target, &url.URL{Host: "url2"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin")
+			sink1 := syslog.NewSyslogSink(target, &url.URL{Host: "url1"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin", false)
+			sink2 := syslog.NewSyslogSink(target, &url.URL{Host: "url2"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin", false)
 
 			groupedSinks.RegisterAppSink(inputChan, sink1)
 
@@ -258,7 +258,7 @@ var _ = Describe("GroupedSink", func() {
 
 		It("closes the inputChan", func() {
 			target := "789"
-			sink := syslog.NewSyslogSink(target, &url.URL{Host: "url1"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin")
+			sink := syslog.NewSyslogSink(target, &url.URL{Host: "url1"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin", false)
 
 			groupedSinks.RegisterAppSink(inputChan, sink)
 			groupedSinks.CloseAndDelete(sink)
@@ -335,7 +335,7 @@ var _ = Describe("GroupedSink", func() {
 			target := "789"
 
 			sink1 := dump.NewDumpSink(target, 10, loggertesthelper.Logger(), time.Second)
-			sink2 := syslog.NewSyslogSink(target, &url.URL{Host: "url"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin")
+			sink2 := syslog.NewSyslogSink(target, &url.URL{Host: "url"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin", false)
 
 			groupedSinks.RegisterAppSink(inputChan, sink1)
 			groupedSinks.RegisterAppSink(inputChan, sink2)
@@ -350,8 +350,8 @@ var _ = Describe("GroupedSink", func() {
 		It("returns only sinks that match the appid and drain URL", func() {
 			target := "789"
 
-			sink1 := syslog.NewSyslogSink(target, &url.URL{Scheme: "syslog", Host: "other sink"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin")
-			sink2 := syslog.NewSyslogSink(target, &url.URL{Scheme: "syslog", Host: "sink we are searching for"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin")
+			sink1 := syslog.NewSyslogSink(target, &url.URL{Scheme: "syslog", Host: "other sink"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin", false)
+			sink2 := syslog.NewSyslogSink(target, &url.URL{Scheme: "syslog", Host: "sink we are searching for"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin", false)
 
 			groupedSinks.RegisterAppSink(inputChan, sink1)
 			groupedSinks.RegisterAppSink(inputChan, sink2)
@@ -362,7 +362,7 @@ var _ = Describe("GroupedSink", func() {
 
 		It("returns nil if no drains are registered", func() {
 			target := "789"
-			sink := syslog.NewSyslogSink(target, &url.URL{Host: "url2"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin")
+			sink := syslog.NewSyslogSink(target, &url.URL{Host: "url2"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin", false)
 
 			groupedSinks.RegisterAppSink(inputChan, sink)
 
@@ -377,8 +377,8 @@ var _ = Describe("GroupedSink", func() {
 	Describe("DumpFor", func() {
 		It("returns only dumps", func() {
 			appId := "789"
-			sink1 := syslog.NewSyslogSink(appId, &url.URL{Host: "url1"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin")
-			sink2 := syslog.NewSyslogSink(appId, &url.URL{Host: "url2"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin")
+			sink1 := syslog.NewSyslogSink(appId, &url.URL{Host: "url1"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin", false)
+			sink2 := syslog.NewSyslogSink(appId, &url.URL{Host: "url2"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin", false)
 			sink3 := dump.NewDumpSink(appId, 5, loggertesthelper.Logger(), time.Second)
 
 			groupedSinks.RegisterAppSink(inputChan, sink1)
@@ -404,7 +404,7 @@ var _ = Describe("GroupedSink", func() {
 		It("returns nil if no dumps are registered", func() {
 			target := "789"
 
-			sink1 := syslog.NewSyslogSink(target, &url.URL{Host: "url1"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin")
+			sink1 := syslog.NewSyslogSink(target, &url.URL{Host: "url1"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin", false)
 
 			groupedSinks.RegisterAppSink(inputChan, sink1)
 
@@ -463,7 +463,7 @@ var _ = Describe("GroupedSink", func() {
 			fakeWriter1 := fakeMessageWriter{RemoteAddress: "1"}
 			fakeWriter2 := fakeMessageWriter{RemoteAddress: "2"}
 
-			sink1 := syslog.NewSyslogSink(appId, &url.URL{Host: "url1"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin")
+			sink1 := syslog.NewSyslogSink(appId, &url.URL{Host: "url1"}, loggertesthelper.Logger(), 100, DummySyslogWriter{}, dummyErrorHandler, "dropsonde-origin", false)
 			sink2 := websocket.NewWebsocketSink(appId, loggertesthelper.Logger(), &fakeWriter1, 100, time.Second, "origin")
 			sink3 := websocket.NewWebsocketSink(appId, loggertesthelper.Logger(), &fakeWriter2, 100, time.Second, "origin")
 

--- a/src/doppler/sinks/syslog/syslog_sink_integration_test.go
+++ b/src/doppler/sinks/syslog/syslog_sink_integration_test.go
@@ -42,7 +42,7 @@ var _ = Describe("SyslogSinkIntegration", func() {
 
 				errorHandler := func(errorMsg, appId string) {}
 
-				syslogSink := syslog.NewSyslogSink(appId, url, loggertesthelper.Logger(), bufferSize, httpsWriter, errorHandler, "dropsonde-origin")
+				syslogSink := syslog.NewSyslogSink(appId, url, loggertesthelper.Logger(), bufferSize, httpsWriter, errorHandler, "dropsonde-origin", false)
 				inputChan := make(chan *events.Envelope)
 
 				defer syslogSink.Disconnect()

--- a/src/doppler/sinkserver/sinkmanager/sink_manager.go
+++ b/src/doppler/sinkserver/sinkmanager/sink_manager.go
@@ -22,24 +22,25 @@ import (
 )
 
 type SinkManager struct {
-	messageDrainBufferSize uint
-	dropsondeOrigin        string
+	messageDrainBufferSize         uint
+	dropsondeOrigin                string
 
-	metrics        *metrics.SinkManagerMetrics
-	recentLogCount uint32
+	metrics                        *metrics.SinkManagerMetrics
+	recentLogCount                 uint32
 
-	doneChannel         chan struct{}
-	errorChannel        chan *events.Envelope
-	urlBlacklistManager *blacklist.URLBlacklistManager
-	sinks               *groupedsinks.GroupedSinks
-	skipCertVerify      bool
-	sinkTimeout         time.Duration
-	sinkIOTimeout       time.Duration
-	metricTTL           time.Duration
-	dialTimeout         time.Duration
-	logger              *gosteno.Logger
+	doneChannel         	       chan struct{}
+	errorChannel        	       chan *events.Envelope
+	urlBlacklistManager 	       *blacklist.URLBlacklistManager
+	sinks               	       *groupedsinks.GroupedSinks
+	skipCertVerify      	       bool
+	sinkTimeout         	       time.Duration
+	sinkIOTimeout       	       time.Duration
+	metricTTL                      time.Duration
+	dialTimeout         	       time.Duration
+	logger              	       *gosteno.Logger
+	enableContainerMetricsToSyslog bool
 
-	stopOnce sync.Once
+	stopOnce                       sync.Once
 }
 
 func New(
@@ -53,22 +54,24 @@ func New(
 	sinkIOTimeout,
 	metricTTL,
 	dialTimeout time.Duration,
+	enableContainerMetricsToSyslog bool,
 ) *SinkManager {
 	return &SinkManager{
-		doneChannel:            make(chan struct{}),
-		errorChannel:           make(chan *events.Envelope, 100),
-		urlBlacklistManager:    blackListManager,
-		sinks:                  groupedsinks.NewGroupedSinks(logger),
-		skipCertVerify:         skipCertVerify,
-		recentLogCount:         maxRetainedLogMessages,
-		metrics:                metrics.NewSinkManagerMetrics(),
-		logger:                 logger,
-		messageDrainBufferSize: messageDrainBufferSize,
-		dropsondeOrigin:        dropsondeOrigin,
-		sinkTimeout:            sinkTimeout,
-		sinkIOTimeout:          sinkIOTimeout,
-		metricTTL:              metricTTL,
-		dialTimeout:            dialTimeout,
+		doneChannel:            	make(chan struct{}),
+		errorChannel:           	make(chan *events.Envelope, 100),
+		urlBlacklistManager:    	blackListManager,
+		sinks:                  	groupedsinks.NewGroupedSinks(logger),
+		skipCertVerify:         	skipCertVerify,
+		recentLogCount:         	maxRetainedLogMessages,
+		metrics:                	metrics.NewSinkManagerMetrics(),
+		logger:                 	logger,
+		messageDrainBufferSize: 	messageDrainBufferSize,
+		dropsondeOrigin:        	dropsondeOrigin,
+		sinkTimeout:            	sinkTimeout,
+		sinkIOTimeout:          	sinkIOTimeout,
+		metricTTL:              	metricTTL,
+		dialTimeout:            	dialTimeout,
+		enableContainerMetricsToSyslog: enableContainerMetricsToSyslog,
 	}
 }
 
@@ -255,6 +258,7 @@ func (sm *SinkManager) registerNewSyslogSink(appId string, syslogSinkURL string)
 		syslogWriter,
 		sm.SendSyslogErrorToLoggregator,
 		sm.dropsondeOrigin,
+		sm.enableContainerMetricsToSyslog,
 	)
 
 	sm.RegisterSink(syslogSink)

--- a/src/doppler/sinkserver/sinkmanager/sink_manager_test.go
+++ b/src/doppler/sinkserver/sinkmanager/sink_manager_test.go
@@ -35,7 +35,7 @@ var _ = Describe("SinkManager", func() {
 	BeforeEach(func() {
 		fakeMetricSender.Reset()
 
-		sinkManager = sinkmanager.New(1, true, blackListManager, logger, 100, "dropsonde-origin", 1*time.Second, 0, 1*time.Second, 1*time.Second)
+		sinkManager = sinkmanager.New(1, true, blackListManager, logger, 100, "dropsonde-origin", 1*time.Second, 0, 1*time.Second, 1*time.Second, true)
 
 		newAppServiceChan = make(chan appservice.AppService)
 		deletedAppServiceChan = make(chan appservice.AppService)
@@ -296,7 +296,7 @@ var _ = Describe("SinkManager", func() {
 			BeforeEach(func() {
 				url := &url.URL{Scheme: "syslog", Host: "localhost:9998"}
 				writer, _ := syslogwriter.NewSyslogWriter(url, "appId", &net.Dialer{Timeout: 500 * time.Millisecond}, 0)
-				syslogSink = syslog.NewSyslogSink("appId", url, loggertesthelper.Logger(), 100, writer, func(string, string) {}, "dropsonde-origin")
+				syslogSink = syslog.NewSyslogSink("appId", url, loggertesthelper.Logger(), 100, writer, func(string, string) {}, "dropsonde-origin", true)
 
 				sinkManager.RegisterSink(syslogSink)
 			})

--- a/src/doppler/sinkserver/sinkserver_dump_test.go
+++ b/src/doppler/sinkserver/sinkserver_dump_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Dumping", func() {
 
 		emptyBlacklist := blacklist.New(nil, logger)
 		sinkManager = sinkmanager.New(1024, false, emptyBlacklist, logger, 100, "dropsonde-origin",
-			2*time.Second, 0, 1*time.Second, 500*time.Millisecond)
+			2*time.Second, 0, 1*time.Second, 500*time.Millisecond, false)
 
 		tempSink := sinkManager
 		services.Add(1)

--- a/src/doppler/sinkserver/websocketserver/websocket_server_test.go
+++ b/src/doppler/sinkserver/websocketserver/websocket_server_test.go
@@ -28,7 +28,7 @@ var _ = Describe("WebsocketServer", func() {
 	var (
 		logger         = loggertesthelper.Logger()
 		server         *websocketserver.WebsocketServer
-		sinkManager    = sinkmanager.New(1024, false, blacklist.New(nil, logger), logger, 100, "dropsonde-origin", 1*time.Second, 0, 1*time.Second, 500*time.Millisecond)
+		sinkManager    = sinkmanager.New(1024, false, blacklist.New(nil, logger), logger, 100, "dropsonde-origin", 1*time.Second, 0, 1*time.Second, 500*time.Millisecond, false)
 		appId          = "my-app"
 		wsReceivedChan chan []byte
 		apiEndpoint    string

--- a/src/truncatingbuffer/buffer_context.go
+++ b/src/truncatingbuffer/buffer_context.go
@@ -42,19 +42,22 @@ func (d *DefaultContext) AppID(envelope *events.Envelope) string {
 
 type LogAllowedContext struct {
 	DefaultContext
+	IsContainerMetricAllowed bool
 }
 
-func NewLogAllowedContext(origin string, destination string) *LogAllowedContext {
+func NewLogAllowedContext(origin string, destination string, isContainerMetricAllowed bool) *LogAllowedContext {
 	return &LogAllowedContext{
-		DefaultContext{
-			destination: destination,
-			origin:      origin,
-		},
+		DefaultContext: DefaultContext{
+					destination: destination,
+					origin:      origin,
+				},
+		IsContainerMetricAllowed: isContainerMetricAllowed,
 	}
 }
 
 func (l *LogAllowedContext) EventAllowed(event events.Envelope_EventType) bool {
-	return event == events.Envelope_LogMessage
+	return event == events.Envelope_LogMessage ||
+		(l.IsContainerMetricAllowed && event == events.Envelope_ContainerMetric)
 }
 
 type SystemContext struct {

--- a/src/truncatingbuffer/buffer_context_test.go
+++ b/src/truncatingbuffer/buffer_context_test.go
@@ -38,14 +38,17 @@ var _ = Describe("BufferContext", func() {
 
 	Context("LogAllowedContext", func() {
 		var logAllowedContext *LogAllowedContext
+		var containerMetricsAllowedContext *LogAllowedContext
 
 		BeforeEach(func() {
-			logAllowedContext = NewLogAllowedContext("origin", "testIdentifier")
+			logAllowedContext = NewLogAllowedContext("origin", "testIdentifier", false)
+			containerMetricsAllowedContext = NewLogAllowedContext("origin", "testIdentifier", true)
 		})
 
 		It("Should return a valid properties", func() {
 			Expect(logAllowedContext.Origin()).To(Equal("origin"))
 			Expect(logAllowedContext.Destination()).To(Equal("testIdentifier"))
+			Expect(logAllowedContext.IsContainerMetricAllowed).To(Equal(false))
 			for _, e := range events.Envelope_EventType_value {
 				event := events.Envelope_EventType(e)
 				allowed := logAllowedContext.EventAllowed(event)
@@ -54,6 +57,21 @@ var _ = Describe("BufferContext", func() {
 				} else {
 					Expect(allowed).To(BeFalse())
 
+				}
+			}
+		})
+
+		It("Should allow container metrics", func() {
+			Expect(containerMetricsAllowedContext.Origin()).To(Equal("origin"))
+			Expect(containerMetricsAllowedContext.Destination()).To(Equal("testIdentifier"))
+			Expect(containerMetricsAllowedContext.IsContainerMetricAllowed).To(Equal(true))
+			for _, e := range events.Envelope_EventType_value {
+				event := events.Envelope_EventType(e)
+				allowed := containerMetricsAllowedContext.EventAllowed(event)
+				if event == events.Envelope_LogMessage || event == events.Envelope_ContainerMetric{
+					Expect(allowed).To(BeTrue())
+				} else {
+					Expect(allowed).To(BeFalse())
 				}
 			}
 		})


### PR DESCRIPTION
Fixes https://github.com/cloudfoundry/loggregator/issues/150

This change enables doppler to forward container metrics to syslog drain.
