### PR TITLE
Allow doppler websocker server host to be configured

### DIFF
--- a/jobs/doppler/spec
+++ b/jobs/doppler/spec
@@ -61,6 +61,9 @@ properties:
     description: "PEM-encoded client key"
     default: ""
 
+  doppler.websocket_host:
+    description: Host for websocker server
+    default: 0.0.0.0
   doppler.outgoing_port:
     description: Port for outgoing log messages via websockets
     default: 8081

--- a/jobs/doppler/templates/doppler.json.erb
+++ b/jobs/doppler/templates/doppler.json.erb
@@ -50,6 +50,7 @@
         if_p("doppler.tls.enable") do |_|
             a[:TLSListenerConfig] = tlsListenerConfig
         end
+        a[:WebsocketHost] = p("doppler.websocket_host")
         a[:OutgoingPort] = p("doppler.outgoing_port")
         a[:GRPC] = grpcListenerConfig
         a[:Zone] = instance_zone

--- a/src/doppler/config/config.go
+++ b/src/doppler/config/config.go
@@ -51,6 +51,7 @@ type Config struct {
 	MetricBatchIntervalMilliseconds uint
 	MetronAddress                   string
 	MonitorIntervalSeconds          uint
+	WebsocketHost                   string
 	OutgoingPort                    uint32
 	GRPC                            GRPC
 	SharedSecret                    string

--- a/src/doppler/config/config_test.go
+++ b/src/doppler/config/config_test.go
@@ -22,6 +22,7 @@ var _ = Describe("Config", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(cfg.IncomingUDPPort).To(Equal(uint32(3456)))
 			Expect(cfg.IncomingTCPPort).To(Equal(uint32(3457)))
+			Expect(cfg.WebsocketHost).To(Equal("0.0.0.0"))
 			Expect(cfg.OutgoingPort).To(Equal(uint32(8080)))
 			Expect(cfg.MessageDrainBufferSize).To(Equal(uint(100)))
 			Expect(cfg.MonitorIntervalSeconds).To(BeEquivalentTo(60))

--- a/src/doppler/config/fixtures/minimal_doppler.json
+++ b/src/doppler/config/fixtures/minimal_doppler.json
@@ -1,4 +1,5 @@
 {
+    "WebsocketHost": "0.0.0.0",
     "OutgoingPort": 8080,
     "GRPC":{
         "Port": 4567,

--- a/src/doppler/doppler.go
+++ b/src/doppler/doppler.go
@@ -165,7 +165,7 @@ func New(
 	doppler.messageRouter = sinkserver.NewMessageRouter(logger, doppler.sinkManager, grpcRouter)
 
 	doppler.websocketServer, err = websocketserver.New(
-		fmt.Sprintf(":%d", conf.OutgoingPort),
+		fmt.Sprintf("%s:%d", conf.WebsocketHost, conf.OutgoingPort),
 		doppler.sinkManager,
 		websocketWriteTimeout,
 		keepAliveInterval,


### PR DESCRIPTION
This PR allows the doppler service to be run on a specific interface (i.e. localhost)

@mdellilo @aemengo