### PR TITLE
Add syslog to metron_agent_windows

### DIFF
--- a/jobs/metron_agent_windows/monit
+++ b/jobs/metron_agent_windows/monit
@@ -3,7 +3,12 @@
     {
       "name": "metron_agent",
       "executable": "powershell",
-      "args": ["C:\\var\\vcap\\jobs\\metron_agent_windows\\bin\\metron_agent_ctl.ps1"]
+      "args": ["C:\\var\\vcap\\jobs\\metron_agent_windows\\bin\\metron_agent_ctl.ps1"],
+      "env": {
+        "__PIPE_SYSLOG_HOST": "<%= p('syslog_daemon_config.address') %>",
+        "__PIPE_SYSLOG_PORT": "<%= p('syslog_daemon_config.port') %>",
+        "__PIPE_SYSLOG_TRANSPORT": "<%= p('syslog_daemon_config.transport') %>"
+      }
     }
   ]
 }

--- a/jobs/metron_agent_windows/spec
+++ b/jobs/metron_agent_windows/spec
@@ -29,11 +29,13 @@ properties:
     default: true
   syslog_daemon_config.address:
     description: "IP address for syslog aggregator"
+    default: ""
   syslog_daemon_config.port:
-    description: "TCP port of syslog aggregator"
+    description: "Port of syslog aggregator"
+    default: ""
   syslog_daemon_config.transport:
-    description: "Transport to be used when forwarding logs (tcp|udp|relp)."
-    default: "tcp"
+    description: "Transport to be used when forwarding logs (tcp|udp)."
+    default: "udp"
   syslog_daemon_config.fallback_addresses:
     description: "Addresses of fallback servers to be used if the primary syslog server is down. Only tcp or relp are supported. Each list entry should consist of \"address\", \"transport\" and \"port\" keys. "
     default: []


### PR DESCRIPTION
A/C: As an operator I should be able to see logs from `metron_agent` in
syslog destination `syslog_daemon_config` defined in my cf manifest.

The support for the new environment variables has been added to AWS
stemcell version `0.0.73` and above.

[#133698951]
https://www.pivotaltracker.com/story/show/133698951

Signed-off-by: Natalie Arellano <narellano@pivotal.io>