### PR TITLE
Fix powershell error handling and exit code.

### DIFF
--- a/packages/golang1.7-windows/packaging
+++ b/packages/golang1.7-windows/packaging
@@ -1,23 +1,18 @@
 . ./loggregator/src/exiter.ps1
 
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
 $GOLANG_ZIP="golang/go1.7.4.windows-amd64.zip"
-try
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+function Unzip
 {
-    Add-Type -AssemblyName System.IO.Compression.FileSystem
-    function Unzip
-    {
-        param([string]$zipfile, [string]$outpath)
+    param([string]$zipfile, [string]$outpath)
 
-        [System.IO.Compression.ZipFile]::ExtractToDirectory($zipfile, $outpath)
-    }
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($zipfile, $outpath)
+}
 
-    $BOSH_INSTALL_TARGET = Resolve-Path "${env:BOSH_INSTALL_TARGET}"
-    Unzip "$GOLANG_ZIP" "$BOSH_INSTALL_TARGET"
-}
-catch
-{
-    Write-Error "Error installing go:"
-    Write-Error $_.Exception.Message
-    Exit 1
-}
+$BOSH_INSTALL_TARGET = Resolve-Path "${env:BOSH_INSTALL_TARGET}"
+Unzip "$GOLANG_ZIP" "$BOSH_INSTALL_TARGET"
+
 Exit 0

--- a/packages/metron_agent_windows/packaging
+++ b/packages/metron_agent_windows/packaging
@@ -1,23 +1,19 @@
 . ./loggregator/src/exiter.ps1
 
+$ErrorActionPreference = "Stop";
+trap { $host.SetShouldExit(1) }
+
 $pkg_name="metron"
 $env:GOROOT="C:\var\vcap\packages\golang1.7-windows\go"
 $env:GOPATH="${PWD}\loggregator"
 $env:PATH="${env:GOROOT}\bin;${env:PATH}"
 
-try {
-    $BOSH_INSTALL_TARGET = Resolve-Path $env:BOSH_INSTALL_TARGET
+$BOSH_INSTALL_TARGET = Resolve-Path $env:BOSH_INSTALL_TARGET
 
-    go build -o "${BOSH_INSTALL_TARGET}\${pkg_name}.exe" "${pkg_name}"
-    if($LASTEXITCODE -ne 0)
-    {
-        Write-Error "Error compiling: ${pkg_name}"
-        Exit 1
-    }
-} catch {
-    Write-Error "Error compiling golang:"
-    Write-Error $_.Exception.Message
-    Exit 1
+go build -o "${BOSH_INSTALL_TARGET}\${pkg_name}.exe" "${pkg_name}"
+if($LASTEXITCODE -ne 0)
+{
+    Write-Error "Error compiling: ${pkg_name}"
 }
 
 Exit 0


### PR DESCRIPTION
Stop script execution on error and return a non-zero exit code. Previously,
PowerShell happily plowed through errors with little regard for traps,
try catch blocks or the non-zero exits within them.

[#134462851]