### PR TITLE
Remove stretchr/testify dependency and submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "src/github.com/cloudfoundry/gosteno"]
 	path = src/github.com/cloudfoundry/gosteno
         url = https://github.com/cloudfoundry/gosteno
-[submodule "src/github.com/stretchr/testify"]
-	path = src/github.com/stretchr/testify
-        url = https://github.com/stretchr/testify
 [submodule "src/github.com/gogo/protobuf"]
 	path = src/github.com/gogo/protobuf
 	url = https://github.com/gogo/protobuf

--- a/src/doppler/sinks/dump/dump_sink_test.go
+++ b/src/doppler/sinks/dump/dump_sink_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cloudfoundry/dropsonde/factories"
 	"github.com/cloudfoundry/loggregatorlib/loggertesthelper"
 	"github.com/cloudfoundry/sonde-go/events"
-	"github.com/stretchr/testify/assert"
 
 	"time"
 
@@ -37,7 +36,7 @@ var _ = Describe("Dump Sink", func() {
 		<-dumpRunnerDone
 
 		data := testDump.Dump()
-		assert.Equal(GinkgoT(), len(data), 1)
+		Expect(len(data)).To(Equal(1))
 		Expect(string(data[0].GetLogMessage().GetMessage())).To(Equal("hi"))
 	})
 


### PR DESCRIPTION
The dependency on testify was necessary to support only a single
assertation. Rather than pull in an entire testing framework for a
single line, this commit removes the dependency and replaces the line
with a similar assertation using Gomega.