### PR TITLE
use more widely compatible Hash syntax

### DIFF
--- a/jobs/boshhmforwarder/templates/boshhmforwarder_config.json.erb
+++ b/jobs/boshhmforwarder/templates/boshhmforwarder_config.json.erb
@@ -8,7 +8,7 @@
     }
 
     if_p("syslog_daemon_config.address") do |_|
-        args.merge!("Syslog": "vcap.boshhmforwarder")
+        args.merge!("Syslog" => "vcap.boshhmforwarder")
     end
 %>
 


### PR DESCRIPTION
```
Error 100: Unable to render instance groups for deployment. Errors are:
   - Unable to render jobs for instance group 'bosh'. Errors are:
     - Unable to render templates for job 'boshhmforwarder'. Errors are:
       - Error filling in template '(unknown)' (line (unknown): boshhmforwarder/boshhmforwarder_config.json.erb:11: syntax error, unexpected ':', expecting ')'
              args.merge!("Syslog": "vcap.boshhmforwarder")
                                   ^
      boshhmforwarder/boshhmforwarder_config.json.erb:11: syntax error, unexpected ')', expecting keyword_end
      boshhmforwarder/boshhmforwarder_config.json.erb:16: syntax error, unexpected end-of-input, expecting keyword_end
      ; _erbout.force_encoding(__ENCODING__)
                                            ^)

```
                                                                                                                              ```
Not sure why ruby 2.3.2 interprets it this way:
```
|ruby-2.3.2@example| wlan-10-81-130-242  12.07.2016 11:09:46 in
~/workspace/example-openstack
± jp |boshhmmetricsforwarder ↑1 ↓1 U:1 ✗| → pry
[1] pry(main)> {}.merge!("a": "b")
=> {:a=>"b"}
[2] pry(main)>
```

and ruby.1.9.3 just won't take it.

```
|ruby-1.9.3-p551| wlan-10-81-130-242  12.07.2016 11:10:50 in
~/workspace/example-openstack
± jp |boshhmmetricsforwarder ↑1 ↓1 U:1 ✗| → pry
[1] pry(main)> {}.merge!("a": "b")
SyntaxError: unexpected ')', expecting $end
```

but the classic syntax produces the desired result:

```
|ruby-2.3.2@example| wlan-10-81-130-242  12.07.2016 11:09:46 in
~/workspace/example-openstack
± jp |boshhmmetricsforwarder ↑1 ↓1 U:1 ✗| → pry
[1] pry(main)> {}.merge!("a": "b")
=> {:a=>"b"}
[2] pry(main)> {}.merge!("a" => "b")
=> {"a"=>"b"}
[3] pry(main)>
```

```
|ruby-1.9.3-p551| wlan-10-81-130-242  12.07.2016 11:10:50 in
~/workspace/example-openstack
± jp |boshhmmetricsforwarder ↑1 ↓1 U:1 ✗| → pry
[1] pry(main)> {}.merge!("a": "b")
SyntaxError: unexpected ')', expecting $end
[1] pry(main)> {}.merge!("a" => "b")
=> {"a"=>"b"}
[2] pry(main)>
```