### PR TITLE
Remove unused and deprecated loggregator consumer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,9 +31,6 @@
 [submodule "src/github.com/gorilla/websocket"]
 	path = src/github.com/gorilla/websocket
 	url = https://github.com/gorilla/websocket
-[submodule "src/github.com/cloudfoundry/loggregator_consumer"]
-	path = src/github.com/cloudfoundry/loggregator_consumer
-	url = https://github.com/cloudfoundry/loggregator_consumer
 [submodule "src/github.com/cloudfoundry/dropsonde"]
 	path = src/github.com/cloudfoundry/dropsonde
 	url = https://github.com/cloudfoundry/dropsonde


### PR DESCRIPTION
Loggregator consumer is deprecated. This pull request removes it from loggregator.