### PR TITLE
Disable noisy logging in test

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -111,14 +111,14 @@ function run_unit {
     print_checkpoint "Running Unit Tests"
     # TODO: remove build_etcd once announcer unit tests no longer depend on it
     build_etcd
-    ginkgo -r --race --randomizeAllSpecs --cover --skipPackage="${not_unit_tests}" $@
+    ginkgo -r --race --randomizeAllSpecs --slowSpecThreshold 20 --skipPackage="${not_unit_tests}" $@
     return $?
 }
 
 function run_integration {
     print_checkpoint "Running Integration Tests"
     build_etcd
-    ginkgo -r --race --randomizeAllSpecs --cover $@ src/integration_tests
+    ginkgo -r --race --randomizeAllSpecs --slowSpecThreshold 20 $@ src/integration_tests
     return $?
 }
 

--- a/src/doppler/component_tests/component_tests_suite_test.go
+++ b/src/doppler/component_tests/component_tests_suite_test.go
@@ -2,6 +2,10 @@ package component_test
 
 import (
 	"integration_tests/binaries"
+	"io/ioutil"
+	"log"
+
+	"google.golang.org/grpc/grpclog"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -10,6 +14,9 @@ import (
 )
 
 func TestComponentTests(t *testing.T) {
+	nullLogger := log.New(ioutil.Discard, "", 0)
+	grpclog.SetLogger(nullLogger)
+
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "ComponentTests Suite")
 }

--- a/src/doppler/grpcmanager/grpcmanager_suite_test.go
+++ b/src/doppler/grpcmanager/grpcmanager_suite_test.go
@@ -6,6 +6,8 @@ import (
 	"io/ioutil"
 	"log"
 
+	"google.golang.org/grpc/grpclog"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -13,6 +15,9 @@ import (
 )
 
 func TestServerhandler(t *testing.T) {
+	nullLogger := log.New(ioutil.Discard, "", 0)
+	grpclog.SetLogger(nullLogger)
+
 	log.SetOutput(ioutil.Discard)
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "gRPC Manager Suite")

--- a/src/tools/logcounterapp/cflib/cflib_suite_test.go
+++ b/src/tools/logcounterapp/cflib/cflib_suite_test.go
@@ -1,6 +1,8 @@
 package cflib_test
 
 import (
+	"log"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -8,6 +10,7 @@ import (
 )
 
 func TestHelpers(t *testing.T) {
+	log.SetOutput(GinkgoWriter)
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "cflib Suite")
 }

--- a/src/trafficcontroller/uaa_client/uaa_suite_test.go
+++ b/src/trafficcontroller/uaa_client/uaa_suite_test.go
@@ -1,6 +1,8 @@
 package uaa_client_test
 
 import (
+	"log"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -8,6 +10,7 @@ import (
 )
 
 func TestUaa(t *testing.T) {
+	log.SetOutput(GinkgoWriter)
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "UaaClient Suite")
 }


### PR DESCRIPTION
- Turn off cover option. We're not using it.
- Use null logger for gRPC
- Send standard logs to ioutil.Discard
- Bump slow test threshold to 20 seconds.