### PR TITLE
Fix compilation error on non-linux machines

### DIFF
--- a/src/monitor/noop_openfd.go
+++ b/src/monitor/noop_openfd.go
@@ -2,17 +2,13 @@
 
 package monitor
 
-import (
-	"time"
-
-	"github.com/cloudfoundry/gosteno"
-)
+import "time"
 
 // LinuxFileDescriptor does nothing if it's not on linux.
 type LinuxFileDescriptor struct {
 }
 
-func NewLinuxFD(time.Duration, *gosteno.Logger) *LinuxFileDescriptor {
+func NewLinuxFD(time.Duration) *LinuxFileDescriptor {
 	return &LinuxFileDescriptor{}
 }
 


### PR DESCRIPTION
The call to `NewLinuxFD` no longer passes in a `logger` in the
loggregator codebase. As a result, when attempting to compile
loggregator on non-Linux machines, compilation fails. This commit fixes
that.