### PR TITLE
Remove empty git hook

### DIFF
--- a/git-hooks/pre-commit
+++ b/git-hooks/pre-commit
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-set -ex


### PR DESCRIPTION
The pre-commit hook is empty. This commit removes it.