### PR TITLE
Remove unnecessary script

### DIFF
--- a/scripts/doppler_integration_tests
+++ b/scripts/doppler_integration_tests
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-trap "echo Exited!; exit 1;" SIGINT SIGTERM
-
-ginkgo -r --race --randomizeAllSpecs src/integration_tests/doppler/


### PR DESCRIPTION
There's no point in having a script to run a common ginkgo command. This
commit removes it.