### PR TITLE
Allow properties to override spec.az

### DIFF
--- a/jobs/doppler/templates/doppler.json.erb
+++ b/jobs/doppler/templates/doppler.json.erb
@@ -2,7 +2,7 @@
     # try and set these properties from a BOSH 2.0 spec object
     job_name = spec.job.name
     instance_id = spec.id
-    instance_zone = spec.az
+    instance_zone = p("doppler.zone", spec.az)
 
     if job_name.nil?
       job_name = name
@@ -10,10 +10,6 @@
 
     if instance_id.nil?
       instance_id = spec.index.to_s
-    end
-
-    if instance_zone.nil?
-      instance_zone = p("doppler.zone")
     end
 
     etcdMachines = p("loggregator.etcd.machines").map { |addr|

--- a/jobs/metron_agent/templates/metron_agent.json.erb
+++ b/jobs/metron_agent/templates/metron_agent.json.erb
@@ -2,7 +2,7 @@
     # try and set these properties from a BOSH 2.0 spec object
     job_name = spec.job.name
     instance_id = spec.id
-    instance_zone = spec.az
+    instance_zone = p("metron_agent.zone", spec.az)
 
     if job_name.nil?
       job_name = name
@@ -11,11 +11,6 @@
     if instance_id.nil?
       instance_id = spec.index.to_s
     end
-
-    if instance_zone.nil?
-      instance_zone = p("metron_agent.zone")
-    end
-
 
     grpcConfig = {
         "Port" => p("metron_agent.grpc_port"),

--- a/jobs/metron_agent_windows/templates/metron_agent.json.erb
+++ b/jobs/metron_agent_windows/templates/metron_agent.json.erb
@@ -2,7 +2,7 @@
     # try and set these properties from a BOSH 2.0 spec object
     job_name = spec.job.name
     instance_id = spec.id
-    instance_zone = spec.az
+    instance_zone = p("metron_agent.zone", spec.az)
 
     if job_name.nil?
       job_name = name
@@ -10,10 +10,6 @@
 
     if instance_id.nil?
       instance_id = spec.index.to_s
-    end
-
-    if instance_zone.nil?
-      instance_zone = p("metron_agent.zone")
     end
 
     incoming_udp_port = nil


### PR DESCRIPTION
Non-BOSH deployments may not have full control over DNS, so the round-robin name for doppler may not correspond to the actual AZ name.  This commit allows the manifest to override spec.az.
These properties will not be set in BOSH 2.0 deployments, so this change should not affect them.