### PR TITLE
Lookup fault domain from Azure metadata if specified

### DIFF
--- a/jobs/doppler/spec
+++ b/jobs/doppler/spec
@@ -25,6 +25,9 @@ provides:
 properties:
   doppler.zone:
     description: Zone of the doppler server
+  doppler.use_azure_fault_domains:
+      description: "Use Azure Fault-Domains to determine the value of the zone. The value of the zone will be z<FD-index>. e.g. z0, z1, etc."
+      default: false
   doppler.maxRetainedLogMessages:
     description: number of log messages to retain per application
     default: 100

--- a/jobs/doppler/templates/doppler_ctl.erb
+++ b/jobs/doppler/templates/doppler_ctl.erb
@@ -32,10 +32,21 @@ case $1 in
     exec >>$LOG_DIR/doppler.stdout.log  \
        2>>$LOG_DIR/doppler.stderr.log
 
+    zone_flag=""
+<% if p("doppler.use_azure_fault_domains") %>
+    set +e
+    azure_fd=$(curl -f --max-time 5 --connect-timeout 5 --silent http://169.254.169.254/metadata/v1/InstanceInfo/FD)
+    if [ 0 -eq $? ]; then
+        zone_flag="--zone=z${azure_fd}"
+    fi
+    set -e
+<% end %>
+
     chown -R vcap:vcap $LOG_DIR
 
     chpst -u vcap:vcap /var/vcap/packages/doppler/doppler \
-         --config /var/vcap/jobs/doppler/config/doppler.json &
+         --config /var/vcap/jobs/doppler/config/doppler.json \
+         ${zone_flag} &
 
     echo $! > $PIDFILE
 

--- a/jobs/metron_agent/spec
+++ b/jobs/metron_agent/spec
@@ -81,6 +81,9 @@ properties:
 
   metron_agent.zone:
     description: "Availability zone where this agent is running"
+  metron_agent.use_azure_fault_domains:
+      description: "Use Azure Fault-Domains to determine the value of the zone. The value of the zone will be z<FD-index>. e.g. z0, z1, etc."
+      default: false
   metron_agent.deployment:
     description: "Name of deployment (added as tag on all outgoing metrics)"
 

--- a/jobs/metron_agent/templates/metron_agent_ctl.erb
+++ b/jobs/metron_agent/templates/metron_agent_ctl.erb
@@ -26,10 +26,21 @@ case $1 in
     exec >>$LOG_DIR/metron_agent.stdout.log \
         2>>$LOG_DIR/metron_agent.stderr.log
 
+    zone_flag=""
+<% if p("metron_agent.use_azure_fault_domains") %>
+    set +e
+    azure_fd=$(curl -f --max-time 5 --connect-timeout 5 --silent http://169.254.169.254/metadata/v1/InstanceInfo/FD)
+    if [ 0 -eq $? ]; then
+        zone_flag="--zone=z${azure_fd}"
+    fi
+    set -e
+<% end %>
+
     chown -R vcap:vcap $LOG_DIR
 
     chpst -u vcap:vcap /var/vcap/packages/metron_agent/metron \
-         --config /var/vcap/jobs/metron_agent/config/metron_agent.json &
+         --config /var/vcap/jobs/metron_agent/config/metron_agent.json \
+         ${zone_flag} &
 
     echo $! > $PIDFILE
 

--- a/src/doppler/main.go
+++ b/src/doppler/main.go
@@ -54,11 +54,20 @@ func main() {
 		"config/doppler.json",
 		"Location of the doppler config json file",
 	)
+	zone := flag.String(
+		"zone",
+		"",
+		"Override the metron zone specified in the config file",
+	)
 	flag.Parse()
 
 	conf, err := config.ParseConfig(*configFile)
 	if err != nil {
 		log.Fatalf("Unable to parse config: %s", err)
+	}
+
+	if *zone != "" {
+		conf.Zone = *zone
 	}
 
 	localIp, err := localip.LocalIP()

--- a/src/metron/main.go
+++ b/src/metron/main.go
@@ -23,11 +23,20 @@ func main() {
 		"config/metron.json",
 		"Location of the Metron config json file",
 	)
+	zone := flag.String(
+		"zone",
+		"",
+		"Override the metron zone specified in the config file",
+	)
 	flag.Parse()
 
 	config, err := api.ParseConfig(*configFilePath)
 	if err != nil {
 		log.Fatalf("Unable to parse config: %s", err)
+	}
+
+	if *zone != "" {
+		config.Zone = *zone
 	}
 
 	clientCreds, err := plumbing.NewCredentials(


### PR DESCRIPTION
Two new job properties (`metron_agent.use_azure_fault_domains`,
and `doppler.use_azure_fault_domains`) can be enabled to tell
metron_agent and doppler to retrieve their zone data from Azure's
metadata service. These values would then be used in those processes
rather than the default behavior of using BOSH's AZ, or the
`metron_agent.zone` and `doppler.zone` values.