### PR TITLE
Fix syslog_drain_binder Windows compilation

### DIFF
--- a/src/syslog_drain_binder/dump_signal_unix.go
+++ b/src/syslog_drain_binder/dump_signal_unix.go
@@ -1,0 +1,16 @@
+// +build !windows
+
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func registerGoRoutineDumpSignalChannel() chan os.Signal {
+	threadDumpChan := make(chan os.Signal)
+	signal.Notify(threadDumpChan, syscall.SIGUSR1)
+
+	return threadDumpChan
+}

--- a/src/syslog_drain_binder/dump_signal_windows.go
+++ b/src/syslog_drain_binder/dump_signal_windows.go
@@ -1,0 +1,8 @@
+package main
+
+import "os"
+
+// Windows does not have a signal equivalent to SIGUSR1.
+func registerGoRoutineDumpSignalChannel() chan os.Signal {
+	return make(chan os.Signal)
+}

--- a/src/syslog_drain_binder/main.go
+++ b/src/syslog_drain_binder/main.go
@@ -3,10 +3,7 @@ package main
 import (
 	"flag"
 	"log"
-	"os"
-	"os/signal"
 	"plumbing"
-	"syscall"
 	"syslog_drain_binder/config"
 	"time"
 
@@ -123,11 +120,4 @@ func main() {
 			}
 		}
 	}
-}
-
-func registerGoRoutineDumpSignalChannel() chan os.Signal {
-	threadDumpChan := make(chan os.Signal)
-	signal.Notify(threadDumpChan, syscall.SIGUSR1)
-
-	return threadDumpChan
 }


### PR DESCRIPTION
The syscall.SIGUSR1 constant is *nix only and prevents the binary from
being built on Windows.  This also broke compilation of the metron
component tests.

You can run `GOOS=windows go test -c -o /dev/null` to check Windows
compilation (this works even when there are no test files).