### PR TITLE
Add doppler_endpoint.shared_secret to doppler link

### DIFF
--- a/jobs/doppler/spec
+++ b/jobs/doppler/spec
@@ -21,6 +21,7 @@ provides:
   type: doppler
   properties:
   - doppler.grpc_port
+  - doppler_endpoint.shared_secret
 
 properties:
   doppler.deployment:

--- a/jobs/metron_agent/spec
+++ b/jobs/metron_agent/spec
@@ -22,6 +22,11 @@ packages:
 - loggregator_common
 - metron_agent
 
+consumes:
+- name: doppler
+  type: doppler
+  optional: true
+
 properties:
   syslog_daemon_config.enable:
     description: "Enable or disable rsyslog configuration for forwarding syslog messages into metron"

--- a/jobs/metron_agent/templates/metron_agent.json.erb
+++ b/jobs/metron_agent/templates/metron_agent.json.erb
@@ -27,7 +27,11 @@
         a[:Deployment] = deployment
         a[:IP] = spec.ip
         a[:Tags] = tags
-        a[:SharedSecret] = p("metron_endpoint.shared_secret")
+        if_p("metron_endpoint.shared_secret") do |_|
+          a[:SharedSecret] = p("metron_endpoint.shared_secret")
+        end.else do
+          a[:SharedSecret] = link("doppler").p("doppler_endpoint.shared_secret")
+        end
         a[:IncomingUDPPort] = p("metron_agent.listening_port")
         a[:DisableUDP] = p("metron_agent.disable_udp")
         a[:PPROFPort] = p("metron_agent.pprof_port")

--- a/jobs/metron_agent_windows/spec
+++ b/jobs/metron_agent_windows/spec
@@ -20,6 +20,11 @@ templates:
 packages:
 - metron_agent_windows
 
+consumes:
+- name: doppler
+  type: doppler
+  optional: true
+
 properties:
   syslog_daemon_config.enable:
     description: "Enable or disable rsyslog configuration for forwarding syslog messages into metron"

--- a/jobs/metron_agent_windows/templates/metron_agent.json.erb
+++ b/jobs/metron_agent_windows/templates/metron_agent.json.erb
@@ -27,7 +27,11 @@
         a[:Deployment] = deployment
         a[:IP] = spec.ip
         a[:Tags] = tags
-        a[:SharedSecret] = p("metron_endpoint.shared_secret")
+        if_p("metron_endpoint.shared_secret") do |_|
+          a[:SharedSecret] = p("metron_endpoint.shared_secret")
+        end.else do
+          a[:SharedSecret] = link("doppler").p("doppler_endpoint.shared_secret")
+        end
         a[:IncomingUDPPort] = p("metron_agent.listening_port")
         a[:DisableUDP] = p("metron_agent.disable_udp")
         a[:PPROFPort] = p("metron_agent.pprof_port")


### PR DESCRIPTION
This is optionally consumed by metron_agent and metron_agent_windows and makes it easier to write deployment manifests (especially if a job in another deployment needs to talk to doppler).
