### PR TITLE
TC doppler proxy refactor

### DIFF
--- a/src/trafficcontroller/internal/proxy/admin_access_middleware.go
+++ b/src/trafficcontroller/internal/proxy/admin_access_middleware.go
@@ -1,0 +1,31 @@
+package proxy
+
+import (
+	"fmt"
+	"net/http"
+	"trafficcontroller/internal/auth"
+)
+
+type AdminAccessMiddleware struct {
+	authorize auth.AdminAccessAuthorizer
+}
+
+func NewAdminAccessMiddleware(a auth.AdminAccessAuthorizer) *AdminAccessMiddleware {
+	return &AdminAccessMiddleware{authorize: a}
+}
+
+func (m *AdminAccessMiddleware) Wrap(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authToken := getAuthToken(r)
+
+		authorized, err := m.authorize(authToken)
+		if !authorized {
+			w.Header().Set("WWW-Authenticate", "Basic")
+			w.WriteHeader(http.StatusUnauthorized)
+			fmt.Fprintf(w, "You are not authorized. %s", err.Error())
+			return
+		}
+
+		h.ServeHTTP(w, r)
+	})
+}

--- a/src/trafficcontroller/internal/proxy/container_metrics_handler.go
+++ b/src/trafficcontroller/internal/proxy/container_metrics_handler.go
@@ -25,6 +25,7 @@ func NewContainerMetricsHandler(grpcConn grpcConnector, t time.Duration) *Contai
 
 func (h *ContainerMetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	startTime := time.Now()
+	// metric-documentation-v1: (dopplerProxy.containermetricsLatency) Measures amount of time to serve the request for container metrics
 	defer sendLatencyMetric("containermetrics", startTime)
 
 	appID := mux.Vars(r)["appID"]

--- a/src/trafficcontroller/internal/proxy/container_metrics_handler.go
+++ b/src/trafficcontroller/internal/proxy/container_metrics_handler.go
@@ -1,0 +1,42 @@
+package proxy
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/mux"
+)
+
+type ContainerMetricsHandler struct {
+	grpcConn grpcConnector
+	timeout  time.Duration
+}
+
+func NewContainerMetricsHandler(grpcConn grpcConnector, t time.Duration) *ContainerMetricsHandler {
+	return &ContainerMetricsHandler{
+		grpcConn: grpcConn,
+		timeout:  t,
+	}
+}
+
+func (h *ContainerMetricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	startTime := time.Now()
+	defer sendLatencyMetric("containermetrics", startTime)
+
+	appID := mux.Vars(r)["appID"]
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx, _ = context.WithDeadline(ctx, time.Now().Add(h.timeout))
+	defer cancel()
+
+	resp := deDupe(h.grpcConn.ContainerMetrics(ctx, appID))
+	if err := ctx.Err(); err != nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		log.Printf("containermetrics request encountered an error: %s", err)
+		return
+	}
+	serveMultiPartResponse(w, resp)
+	return
+}

--- a/src/trafficcontroller/internal/proxy/doppler_proxy_test.go
+++ b/src/trafficcontroller/internal/proxy/doppler_proxy_test.go
@@ -438,13 +438,16 @@ var _ = Describe("ServeHTTP()", func() {
 			Expect(recorder.Code).To(Equal(http.StatusOK))
 		})
 
-		It("sets the passed value as a cookie", func() {
+		It("sets the passed value as a cookie and sets CORS headers", func() {
 			req, _ := http.NewRequest("POST", "/set-cookie", strings.NewReader("CookieName=cookie&CookieValue=monster"))
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			req.Header.Set("Origin", "fake-origin-string")
 
 			dopplerProxy.ServeHTTP(recorder, req)
 
 			Expect(recorder.Header().Get("Set-Cookie")).To(Equal("cookie=monster; Domain=cookieDomain; Secure"))
+			Expect(recorder.Header().Get("Access-Control-Allow-Origin")).To(Equal("fake-origin-string"))
+			Expect(recorder.Header().Get("Access-Control-Allow-Credentials")).To(Equal("true"))
 		})
 
 		It("returns a bad request if the form does not parse", func() {
@@ -454,17 +457,6 @@ var _ = Describe("ServeHTTP()", func() {
 			dopplerProxy.ServeHTTP(recorder, req)
 
 			Expect(recorder.Code).To(Equal(http.StatusBadRequest))
-		})
-
-		It("sets required CORS headers", func() {
-			req, _ := http.NewRequest("POST", "/set-cookie", nil)
-			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-			req.Header.Set("Origin", "fake-origin-string")
-
-			dopplerProxy.ServeHTTP(recorder, req)
-
-			Expect(recorder.Header().Get("Access-Control-Allow-Origin")).To(Equal("fake-origin-string"))
-			Expect(recorder.Header().Get("Access-Control-Allow-Credentials")).To(Equal("true"))
 		})
 	})
 

--- a/src/trafficcontroller/internal/proxy/firehose_handler.go
+++ b/src/trafficcontroller/internal/proxy/firehose_handler.go
@@ -1,0 +1,47 @@
+package proxy
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"plumbing"
+	"sync/atomic"
+
+	"github.com/gorilla/mux"
+)
+
+const firehoseID = "firehose"
+
+type FirehoseHandler struct {
+	grpcConn grpcConnector
+	counter  int64
+}
+
+func NewFirehoseHandler(grpcConn grpcConnector) *FirehoseHandler {
+	return &FirehoseHandler{grpcConn: grpcConn}
+}
+
+func (h *FirehoseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	atomic.AddInt64(&h.counter, 1)
+	defer atomic.AddInt64(&h.counter, -1)
+
+	subID := mux.Vars(r)["subID"]
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client, err := h.grpcConn.Subscribe(ctx, &plumbing.SubscriptionRequest{
+		ShardID: subID,
+	})
+	if err != nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		log.Printf("error occurred when subscribing to doppler: %s", err)
+		return
+	}
+
+	serveWS(firehoseID, subID, w, r, client)
+}
+
+func (h *FirehoseHandler) Count() int64 {
+	return atomic.LoadInt64(&h.counter)
+}

--- a/src/trafficcontroller/internal/proxy/log_access_middleware.go
+++ b/src/trafficcontroller/internal/proxy/log_access_middleware.go
@@ -1,0 +1,44 @@
+package proxy
+
+import (
+	"net/http"
+	"trafficcontroller/internal/auth"
+
+	"github.com/gorilla/mux"
+)
+
+type LogAccessMiddleware struct {
+	handler   http.Handler
+	authorize auth.LogAccessAuthorizer
+}
+
+func NewLogAccessMiddleware(authorize auth.LogAccessAuthorizer, h http.Handler) *LogAccessMiddleware {
+	return &LogAccessMiddleware{
+		authorize: authorize,
+		handler:   h,
+	}
+}
+
+func (m *LogAccessMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	appID := mux.Vars(r)["appID"]
+	authToken := getAuthToken(r)
+
+	status, _ := m.authorize(authToken, appID)
+	if status != http.StatusOK {
+		switch status {
+		case http.StatusUnauthorized:
+			w.WriteHeader(status)
+			w.Header().Set("WWW-Authenticate", "Basic")
+		case http.StatusForbidden, http.StatusNotFound:
+			status = http.StatusNotFound
+		default:
+			status = http.StatusInternalServerError
+		}
+
+		w.WriteHeader(status)
+
+		return
+	}
+
+	m.handler.ServeHTTP(w, r)
+}

--- a/src/trafficcontroller/internal/proxy/log_access_middleware.go
+++ b/src/trafficcontroller/internal/proxy/log_access_middleware.go
@@ -8,37 +8,37 @@ import (
 )
 
 type LogAccessMiddleware struct {
-	handler   http.Handler
 	authorize auth.LogAccessAuthorizer
 }
 
-func NewLogAccessMiddleware(authorize auth.LogAccessAuthorizer, h http.Handler) *LogAccessMiddleware {
+func NewLogAccessMiddleware(authorize auth.LogAccessAuthorizer) *LogAccessMiddleware {
 	return &LogAccessMiddleware{
 		authorize: authorize,
-		handler:   h,
 	}
 }
 
-func (m *LogAccessMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	appID := mux.Vars(r)["appID"]
-	authToken := getAuthToken(r)
+func (m *LogAccessMiddleware) Wrap(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		appID := mux.Vars(r)["appID"]
+		authToken := getAuthToken(r)
 
-	status, _ := m.authorize(authToken, appID)
-	if status != http.StatusOK {
-		switch status {
-		case http.StatusUnauthorized:
+		status, _ := m.authorize(authToken, appID)
+		if status != http.StatusOK {
+			switch status {
+			case http.StatusUnauthorized:
+				w.WriteHeader(status)
+				w.Header().Set("WWW-Authenticate", "Basic")
+			case http.StatusForbidden, http.StatusNotFound:
+				status = http.StatusNotFound
+			default:
+				status = http.StatusInternalServerError
+			}
+
 			w.WriteHeader(status)
-			w.Header().Set("WWW-Authenticate", "Basic")
-		case http.StatusForbidden, http.StatusNotFound:
-			status = http.StatusNotFound
-		default:
-			status = http.StatusInternalServerError
+
+			return
 		}
 
-		w.WriteHeader(status)
-
-		return
-	}
-
-	m.handler.ServeHTTP(w, r)
+		h.ServeHTTP(w, r)
+	})
 }

--- a/src/trafficcontroller/internal/proxy/recent_logs_handler.go
+++ b/src/trafficcontroller/internal/proxy/recent_logs_handler.go
@@ -24,6 +24,7 @@ func NewRecentLogsHandler(grpcConn grpcConnector, t time.Duration) *RecentLogsHa
 
 func (h *RecentLogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	startTime := time.Now()
+	// metric-documentation-v1: (dopplerProxy.recentlogsLatency) Measures amount of time to serve the request for recent logs
 	defer sendLatencyMetric("recentlogs", startTime)
 
 	appID := mux.Vars(r)["appID"]

--- a/src/trafficcontroller/internal/proxy/recent_logs_handler.go
+++ b/src/trafficcontroller/internal/proxy/recent_logs_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -44,5 +45,19 @@ func (h *RecentLogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	serveMultiPartResponse(w, resp)
-	return
+}
+
+func limitFrom(r *http.Request) (int, bool) {
+	query := r.URL.Query()
+	values, ok := query["limit"]
+	if !ok {
+		return 0, false
+	}
+
+	value, err := strconv.Atoi(values[0])
+	if err != nil || value < 0 {
+		return 0, false
+	}
+
+	return value, true
 }

--- a/src/trafficcontroller/internal/proxy/recent_logs_handler.go
+++ b/src/trafficcontroller/internal/proxy/recent_logs_handler.go
@@ -1,0 +1,48 @@
+package proxy
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/mux"
+)
+
+type RecentLogsHandler struct {
+	grpcConn grpcConnector
+	timeout  time.Duration
+}
+
+func NewRecentLogsHandler(grpcConn grpcConnector, t time.Duration) *RecentLogsHandler {
+	return &RecentLogsHandler{
+		grpcConn: grpcConn,
+		timeout:  t,
+	}
+}
+
+func (h *RecentLogsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	startTime := time.Now()
+	defer sendLatencyMetric("recentlogs", startTime)
+
+	appID := mux.Vars(r)["appID"]
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx, _ = context.WithDeadline(ctx, time.Now().Add(h.timeout))
+	defer cancel()
+
+	resp := h.grpcConn.RecentLogs(ctx, appID)
+	if err := ctx.Err(); err != nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		log.Printf("recentlogs request encountered an error: %s", err)
+		return
+	}
+
+	limit, ok := limitFrom(r)
+	if ok && len(resp) > limit {
+		resp = resp[:limit]
+	}
+
+	serveMultiPartResponse(w, resp)
+	return
+}

--- a/src/trafficcontroller/internal/proxy/set_cookie_handler.go
+++ b/src/trafficcontroller/internal/proxy/set_cookie_handler.go
@@ -1,0 +1,33 @@
+package proxy
+
+import "net/http"
+
+type SetCookieHandler struct {
+	domain string
+}
+
+func NewSetCookieHandler(domain string) *SetCookieHandler {
+	return &SetCookieHandler{
+		domain: domain,
+	}
+}
+
+func (h SetCookieHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+	}
+
+	cookieName := r.FormValue("CookieName")
+	cookieValue := r.FormValue("CookieValue")
+	origin := r.Header.Get("Origin")
+
+	http.SetCookie(w, &http.Cookie{
+		Name:   cookieName,
+		Value:  cookieValue,
+		Domain: h.domain,
+		Secure: true,
+	})
+
+	w.Header().Add("Access-Control-Allow-Credentials", "true")
+	w.Header().Add("Access-Control-Allow-Origin", origin)
+}

--- a/src/trafficcontroller/internal/proxy/set_cookie_handler.go
+++ b/src/trafficcontroller/internal/proxy/set_cookie_handler.go
@@ -15,6 +15,7 @@ func NewSetCookieHandler(domain string) *SetCookieHandler {
 func (h SetCookieHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
+		return
 	}
 
 	cookieName := r.FormValue("CookieName")

--- a/src/trafficcontroller/internal/proxy/stream_handler.go
+++ b/src/trafficcontroller/internal/proxy/stream_handler.go
@@ -1,0 +1,45 @@
+package proxy
+
+import (
+	"context"
+	"net/http"
+	"plumbing"
+	"sync/atomic"
+
+	"github.com/gorilla/mux"
+)
+
+type StreamHandler struct {
+	grpcConn grpcConnector
+	counter  int64
+}
+
+func NewStreamHandler(grpcConn grpcConnector) *StreamHandler {
+	return &StreamHandler{grpcConn: grpcConn}
+}
+
+func (h *StreamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	atomic.AddInt64(&h.counter, 1)
+	defer atomic.AddInt64(&h.counter, -1)
+
+	appID := mux.Vars(r)["appID"]
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client, err := h.grpcConn.Subscribe(ctx, &plumbing.SubscriptionRequest{
+		Filter: &plumbing.Filter{
+			AppID: appID,
+		},
+	})
+	if err != nil {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		return
+	}
+
+	serveWS("stream", appID, w, r, client)
+}
+
+func (h *StreamHandler) Count() int64 {
+	return atomic.LoadInt64(&h.counter)
+}


### PR DESCRIPTION
This PR cleans up the doppler proxy in traffic controller moving all HTTP endpoints to their own HTTP handlers and moving authentication concerns to middleware.

This PR also fixes the following bugs:

* /set-cookie would still set cookie and CORS headers on a bad request
* Latency metrics for recent logs and container metrics do not calculate time to get get those resources.

I will make a future PR to refactor the `doppler_proxy_test.go` to make it easier to parse as well.