### PR TITLE
Consolidate calls to dropsonde/metrics in Traffic Controller behind shim

### DIFF
--- a/src/trafficcontroller/app/shim.go
+++ b/src/trafficcontroller/app/shim.go
@@ -1,0 +1,20 @@
+package app
+
+import "github.com/cloudfoundry/dropsonde/metrics"
+
+// metricShim isolates all uses of the dropsonde metrics behind a clean
+// interface. Any code which must send metrics should inject this shim.
+// The shim exists for two reasons.
+//
+// First, the dropsonde metrics library relies on global state, which is prone
+// to race conditions and is difficult to test reliably. The shim exists to be
+// injected as an interface, which may be replaced with a double in test.
+//
+// Second, the shim exists to make replacing dropsonde metrics wholesale as
+// simple as changing this file. If we know what interface we need for
+// metrics, swapping implementations is much easier.
+type metricShim struct{}
+
+func (*metricShim) SendValue(name string, value float64, unit string) error {
+	return metrics.SendValue(name, value, unit)
+}

--- a/src/trafficcontroller/app/traffic_controller.go
+++ b/src/trafficcontroller/app/traffic_controller.go
@@ -4,16 +4,16 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"metricemitter"
 	"net/http"
 	"os"
 	"os/signal"
-	"profiler"
 	"time"
 
 	"dopplerservice"
+	"metricemitter"
 	"monitor"
 	"plumbing"
+	"profiler"
 	"trafficcontroller/internal/auth"
 	"trafficcontroller/internal/proxy"
 
@@ -149,6 +149,7 @@ func (t *trafficController) Start() {
 			grpcConnector,
 			"doppler."+t.conf.SystemDomain,
 			15*time.Second,
+			&metricShim{},
 		),
 	)
 	if accessMiddleware != nil {

--- a/src/trafficcontroller/internal/proxy/firehose_handler.go
+++ b/src/trafficcontroller/internal/proxy/firehose_handler.go
@@ -13,12 +13,16 @@ import (
 const firehoseID = "firehose"
 
 type FirehoseHandler struct {
+	server   *WebSocketServer
 	grpcConn grpcConnector
 	counter  int64
 }
 
-func NewFirehoseHandler(grpcConn grpcConnector) *FirehoseHandler {
-	return &FirehoseHandler{grpcConn: grpcConn}
+func NewFirehoseHandler(grpcConn grpcConnector, w *WebSocketServer) *FirehoseHandler {
+	return &FirehoseHandler{
+		grpcConn: grpcConn,
+		server:   w,
+	}
 }
 
 func (h *FirehoseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -58,7 +62,7 @@ func (h *FirehoseHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	serveWS(firehoseID, subID, w, r, client)
+	h.server.serveWS(firehoseID, subID, w, r, client)
 }
 
 func (h *FirehoseHandler) Count() int64 {

--- a/src/trafficcontroller/internal/proxy/stream_handler.go
+++ b/src/trafficcontroller/internal/proxy/stream_handler.go
@@ -10,12 +10,16 @@ import (
 )
 
 type StreamHandler struct {
+	server   *WebSocketServer
 	grpcConn grpcConnector
 	counter  int64
 }
 
-func NewStreamHandler(grpcConn grpcConnector) *StreamHandler {
-	return &StreamHandler{grpcConn: grpcConn}
+func NewStreamHandler(grpcConn grpcConnector, w *WebSocketServer) *StreamHandler {
+	return &StreamHandler{
+		grpcConn: grpcConn,
+		server:   w,
+	}
 }
 
 func (h *StreamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -37,7 +41,7 @@ func (h *StreamHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	serveWS("stream", appID, w, r, client)
+	h.server.serveWS("stream", appID, w, r, client)
 }
 
 func (h *StreamHandler) Count() int64 {

--- a/src/trafficcontroller/internal/proxy/stream_handler_test.go
+++ b/src/trafficcontroller/internal/proxy/stream_handler_test.go
@@ -19,7 +19,8 @@ var _ = Describe("StreamHandler", func() {
 		dopplerProxy *proxy.DopplerProxy
 		recorder     *httptest.ResponseRecorder
 
-		connector *SpyGRPCConnector
+		connector  *SpyGRPCConnector
+		mockSender *mockMetricSender
 	)
 
 	BeforeEach(func() {
@@ -27,6 +28,7 @@ var _ = Describe("StreamHandler", func() {
 		adminAuth = AdminAuthorizer{Result: AuthorizerResult{Status: http.StatusOK}}
 
 		connector = newSpyGRPCConnector(nil)
+		mockSender = newMockMetricSender()
 
 		dopplerProxy = proxy.NewDopplerProxy(
 			auth.Authorize,
@@ -34,11 +36,10 @@ var _ = Describe("StreamHandler", func() {
 			connector,
 			"cookieDomain",
 			50*time.Millisecond,
+			mockSender,
 		)
 
 		recorder = httptest.NewRecorder()
-
-		fakeMetricSender.Reset()
 	})
 
 	Context("if the app id is forbidden", func() {

--- a/src/trafficcontroller/internal/proxy/web_socket_server.go
+++ b/src/trafficcontroller/internal/proxy/web_socket_server.go
@@ -1,0 +1,56 @@
+package proxy
+
+import (
+	"log"
+	"net/http"
+	"time"
+)
+
+type WebSocketServer struct {
+	metricSender metricSender
+}
+
+func (s *WebSocketServer) serveWS(
+	endpointType string,
+	streamID string,
+	w http.ResponseWriter,
+	r *http.Request,
+	recv func() ([]byte, error),
+) {
+	dopplerEndpoint := NewDopplerEndpoint(endpointType, streamID, false)
+	data := make(chan []byte)
+	handler := dopplerEndpoint.HProvider(data)
+
+	go func() {
+		defer close(data)
+		timer := time.NewTimer(5 * time.Second)
+		timer.Stop()
+		for {
+			resp, err := recv()
+			if err != nil {
+				log.Printf("error receiving from doppler via gRPC %s", err)
+				return
+			}
+
+			if resp == nil {
+				continue
+			}
+
+			timer.Reset(5 * time.Second)
+			select {
+			case data <- resp:
+				if !timer.Stop() {
+					<-timer.C
+				}
+			case <-timer.C:
+				// metric-documentation-v1: (dopplerProxy.slowConsumer) A slow consumer of the
+				// websocket stream
+				s.metricSender.SendValue("dopplerProxy.slowConsumer", 1, "consumer")
+				log.Print("Doppler Proxy: Slow Consumer")
+				return
+			}
+		}
+	}()
+
+	handler.ServeHTTP(w, r)
+}


### PR DESCRIPTION
The dropsonde/metrics package is based on global state. As a result, it is
hard to test and conceals a type's true dependencies. This commit moves all
calls to metrics.SendValue into a shim, which is then injected into any
handler which requires it.

By moving the metrics behind a shim, we are now in a better position to
outright replace it with more recent and reliable code for metrics.

As part of the metrics work, this commit also groups all web socket concerns
into a type, which is injected into any handlers which require it. The web
socket type, WebSocketServer, likewise consumes the metrics shim to emit
metrics.