### PR TITLE
RLP and TC ctl scripts kill process before starting

### DIFF
--- a/jobs/loggregator_trafficcontroller/spec
+++ b/jobs/loggregator_trafficcontroller/spec
@@ -12,7 +12,6 @@ templates:
   dns_health_check.erb: bin/dns_health_check
 
 packages:
-- loggregator_common
 - loggregator_trafficcontroller
 
 provides:

--- a/jobs/loggregator_trafficcontroller/templates/loggregator_trafficcontroller_ctl.erb
+++ b/jobs/loggregator_trafficcontroller/templates/loggregator_trafficcontroller_ctl.erb
@@ -17,12 +17,15 @@ mkdir -p $LOG_DIR
 touch $LOG_DIR/loggregator_trafficcontroller_security_events.log
 <% end %>
 
-source /var/vcap/packages/loggregator_common/pid_utils.sh
-
 case $1 in
 
   start)
-    pid_guard $PIDFILE "LoggregatorTrafficController"
+    set +e
+      killall -15 trafficcontroller
+      killall -9 trafficcontroller
+      killall -2 trafficcontroller
+      killall -3 trafficcontroller
+    set -e
 
     <% if p("traffic_controller.locked_memory_limit") != "kernel" %>
     ulimit -l <%= p("traffic_controller.locked_memory_limit") %>
@@ -43,7 +46,14 @@ case $1 in
     ;;
 
   stop)
-    kill_and_wait $PIDFILE 40
+    set +e
+      killall -15 trafficcontroller
+      killall -9 trafficcontroller
+      killall -2 trafficcontroller
+      killall -3 trafficcontroller
+    set -e
+
+    rm -f $PIDFILE
 
     ;;
 

--- a/jobs/reverse_log_proxy/templates/reverse_log_proxy_ctl.erb
+++ b/jobs/reverse_log_proxy/templates/reverse_log_proxy_ctl.erb
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 RUN_DIR=/var/vcap/sys/run/reverse_log_proxy
 LOG_DIR=/var/vcap/sys/log/reverse_log_proxy
@@ -10,51 +10,65 @@ PACKAGE_DIR=/var/vcap/packages/reverse_log_proxy
 
 case $1 in
 
-start)
-mkdir -p $RUN_DIR $LOG_DIR
-chown -R vcap:vcap $RUN_DIR $LOG_DIR
+  start)
+    set +e
+      killall -15 rlp
+      killall -9 rlp
+      killall -2 rlp
+      killall -3 rlp
+    set -e
 
-cd $PACKAGE_DIR
+    mkdir -p $RUN_DIR $LOG_DIR
+    chown -R vcap:vcap $RUN_DIR $LOG_DIR
 
-ulimit -n 8192
+    cd $PACKAGE_DIR
 
-<%
-    ingress_addrs = []
-    if_link("doppler") { |ds|
-        ingress_addrs = ds.instances.map do |instance|
-            "#{instance.address}:#{ds.p('doppler.grpc_port')}"
-        end
-    }.else {
-        ingress_addrs = p('loggregator.doppler.addrs').map do |addr|
-            "#{addr}:#{p('loggregator.doppler.grpc_port')}"
-        end
-    }
-%>
+    ulimit -n 8192
 
-echo $$ > $PIDFILE
-exec chpst -u vcap:vcap ./rlp \
-  --pprof-port="<%= p('reverse_log_proxy.pprof.port') %>" \
-  --health-addr="<%= p('reverse_log_proxy.health_addr') %>" \
-  --egress-port="<%= p('reverse_log_proxy.egress.port') %>" \
-  --ingress-addrs="<%= ingress_addrs.join(',') %>" \
-  --ca=$CERT_DIR/mutual_tls_ca.crt \
-  --cert=$CERT_DIR/reverse_log_proxy.crt \
-  --key=$CERT_DIR/reverse_log_proxy.key \
-  --cipher-suites="<%= p('loggregator.tls.cipher_suites') %>" \
-  --metron-addr="<%= [ p('metron_endpoint.host'), p('metron_endpoint.grpc_port')].join(':') %>" \
-  --metric-emitter-interval="<%= p('metric_emitter.interval') %>" \
-  &>> ${LOG_DIR}/rlp.log
+    <%
+        ingress_addrs = []
+        if_link("doppler") { |ds|
+            ingress_addrs = ds.instances.map do |instance|
+                "#{instance.address}:#{ds.p('doppler.grpc_port')}"
+            end
+        }.else {
+            ingress_addrs = p('loggregator.doppler.addrs').map do |addr|
+                "#{addr}:#{p('loggregator.doppler.grpc_port')}"
+            end
+        }
+    %>
 
-;;
+    echo $$ > $PIDFILE
+    exec chpst -u vcap:vcap ./rlp \
+      --pprof-port="<%= p('reverse_log_proxy.pprof.port') %>" \
+      --health-addr="<%= p('reverse_log_proxy.health_addr') %>" \
+      --egress-port="<%= p('reverse_log_proxy.egress.port') %>" \
+      --ingress-addrs="<%= ingress_addrs.join(',') %>" \
+      --ca=$CERT_DIR/mutual_tls_ca.crt \
+      --cert=$CERT_DIR/reverse_log_proxy.crt \
+      --key=$CERT_DIR/reverse_log_proxy.key \
+      --cipher-suites="<%= p('loggregator.tls.cipher_suites') %>" \
+      --metron-addr="<%= [ p('metron_endpoint.host'), p('metron_endpoint.grpc_port')].join(':') %>" \
+      --metric-emitter-interval="<%= p('metric_emitter.interval') %>" \
+      &>> ${LOG_DIR}/rlp.log
 
-stop)
+    ;;
 
-killall -9 rlp
-rm -f $PIDFILE
+  stop)
+    set +e
+      killall -15 rlp
+      killall -9 rlp
+      killall -2 rlp
+      killall -3 rlp
+    set -e
 
-;;
+    rm -f $PIDFILE
 
-*)
-echo "Usage: ctl {start|stop}" ;;
+    ;;
+
+  *)
+    echo "Usage: reverse_log_proxy_ctl {start|stop}"
+
+    ;;
 
 esac


### PR DESCRIPTION
When starting RLP we want to ensure there is not already a running instance of the RLP.

Also fixed indentation of CTL script.

Fixes #285.