### PR TITLE
Add write deadline for websocket connection to avoid long hang

### DIFF
--- a/src/code.cloudfoundry.org/loggregator/trafficcontroller/internal/proxy/websocket_handler.go
+++ b/src/code.cloudfoundry.org/loggregator/trafficcontroller/internal/proxy/websocket_handler.go
@@ -38,6 +38,7 @@ func (h *websocketHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		log.Printf("websocket handler: Not a websocket handshake: %s", err)
 		return
 	}
+	ws.SetWriteDeadline(6 * time.Second)
 	defer ws.Close()
 
 	closeCode, closeMessage := h.runWebsocketUntilClosed(ws)

--- a/src/code.cloudfoundry.org/loggregator/trafficcontroller/internal/proxy/websocket_handler.go
+++ b/src/code.cloudfoundry.org/loggregator/trafficcontroller/internal/proxy/websocket_handler.go
@@ -38,7 +38,6 @@ func (h *websocketHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		log.Printf("websocket handler: Not a websocket handshake: %s", err)
 		return
 	}
-	ws.SetWriteDeadline(6 * time.Second)
 	defer ws.Close()
 
 	closeCode, closeMessage := h.runWebsocketUntilClosed(ws)
@@ -78,6 +77,7 @@ func (h *websocketHandler) runWebsocketUntilClosed(ws *websocket.Conn) (closeCod
 			if !ok {
 				return
 			}
+			ws.SetWriteDeadline(time.Now().Add(6 * time.Second))
 			err := ws.WriteMessage(websocket.BinaryMessage, message)
 			if err != nil {
 				return


### PR DESCRIPTION
When there is a slow Firehose client, the `ws.WriteMessage` will block there for a long time until client drain the messages and there is free space for the write.

By design, TrafficaController will close the message channel in 5 seconds if the Firehose client slow. But this `ws.WriteMessage` may hang out there for a long time for a slow client which results in "the 5 seconds time out" doesn't take effective as expect.

The PR is setting up a write deadline so if WriteMessage timed out, we basically does a clean shutdown for that websocket