### PR TITLE
set grpc keep alive between the client and the doppler server

### DIFF
--- a/src/code.cloudfoundry.org/loggregator/doppler/internal/listeners/grpc_listener.go
+++ b/src/code.cloudfoundry.org/loggregator/doppler/internal/listeners/grpc_listener.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"time"
 
 	"code.cloudfoundry.org/loggregator/diodes"
 	"code.cloudfoundry.org/loggregator/doppler/app"
@@ -19,6 +20,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
 )
 
 // MetricClient creates new CounterMetrics to be emitted periodically.
@@ -63,7 +65,11 @@ func NewGRPCListener(
 		log.Printf("Failed to start listener (port=%d) for gRPC: %s", conf.Port, err)
 		return nil, err
 	}
-	grpcServer := grpc.NewServer(grpc.Creds(transportCreds))
+	kp := keepalive.EnforcementPolicy{
+		MinTime:             5 * time.Minute,
+		PermitWithoutStream: true,
+	}
+	grpcServer := grpc.NewServer(grpc.Creds(transportCreds), grpc.KeepaliveEnforcementPolicy(kp))
 
 	// v1 ingress
 	plumbingv1.RegisterDopplerIngestorServer(


### PR DESCRIPTION
Our corporate infrastructure makes heavy use of physical firewall devices which by default are configured to drop connections after a period of inactivity (30 minutes). Setting grpc keep alive between traffic controller and doppler server prevents the connections in the pool from being dropped. 