### PR TITLE
Feature Proposal: Use pubsub instead of map based routing

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -112,3 +112,6 @@
 [submodule "src/github.com/prometheus/procfs"]
 	path = src/github.com/prometheus/procfs
 	url = https://github.com/prometheus/procfs
+[submodule "src/github.com/apoydence/pubsub"]
+	path = src/github.com/apoydence/pubsub
+	url = https://github.com/apoydence/pubsub

--- a/packages/doppler/spec
+++ b/packages/doppler/spec
@@ -37,6 +37,9 @@ files:
 - loggregator/src/code.cloudfoundry.org/loggregator/plumbing/v2/*.go # gosub
 - loggregator/src/code.cloudfoundry.org/loggregator/profiler/*.go # gosub
 - loggregator/src/code.cloudfoundry.org/workpool/*.go # gosub
+- loggregator/src/github.com/apoydence/pubsub/*.go # gosub
+- loggregator/src/github.com/apoydence/pubsub/internal/node/*.go # gosub
+- loggregator/src/github.com/apoydence/pubsub/pubsub-gen/setters/*.go # gosub
 - loggregator/src/github.com/beorn7/perks/quantile/*.go # gosub
 - loggregator/src/github.com/cloudfoundry/diodes/*.go # gosub
 - loggregator/src/github.com/cloudfoundry/dropsonde/*.go # gosub

--- a/src/code.cloudfoundry.org/loggregator/doppler/internal/grpcmanager/v1/doppler_server.go
+++ b/src/code.cloudfoundry.org/loggregator/doppler/internal/grpcmanager/v1/doppler_server.go
@@ -32,9 +32,7 @@ type Registrar interface {
 }
 
 // DataSetter accepts writes of marshalled data.
-type DataSetter interface {
-	Set(data []byte)
-}
+type DataSetter func(data []byte)
 
 // DataDumper dumps Envelopes for container metrics and recent logs requests.
 type DataDumper interface {
@@ -156,7 +154,7 @@ func marshalEnvelopes(envelopes []*events.Envelope) [][]byte {
 
 func (m *DopplerServer) sendData(req *plumbing.SubscriptionRequest, sender sender) error {
 	d := diodes.NewOneToOne(1000, m)
-	cleanup := m.registrar.Register(req, d)
+	cleanup := m.registrar.Register(req, d.Set)
 	defer cleanup()
 
 	var done int64
@@ -200,7 +198,7 @@ func (b *batchWriter) Write(batch [][]byte) {
 
 func (m *DopplerServer) sendBatchData(req *plumbing.SubscriptionRequest, sender plumbing.Doppler_BatchSubscribeServer) error {
 	d := diodes.NewOneToOne(1000, m)
-	cleanup := m.registrar.Register(req, d)
+	cleanup := m.registrar.Register(req, d.Set)
 	defer cleanup()
 
 	errStream := make(chan error, 1)

--- a/src/code.cloudfoundry.org/loggregator/doppler/internal/grpcmanager/v1/doppler_server_test.go
+++ b/src/code.cloudfoundry.org/loggregator/doppler/internal/grpcmanager/v1/doppler_server_test.go
@@ -137,7 +137,7 @@ var _ = Describe("v1 doppler server", func() {
 				defer close(done)
 				go func() {
 					for {
-						setter.Set([]byte("some-data"))
+						setter([]byte("some-data"))
 						select {
 						case <-done:
 							return
@@ -177,9 +177,9 @@ var _ = Describe("v1 doppler server", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				setter := fetchSetter(mockRegistrar)
-				setter.Set([]byte("some-data-0"))
-				setter.Set([]byte("some-data-1"))
-				setter.Set([]byte("some-data-2"))
+				setter([]byte("some-data-0"))
+				setter([]byte("some-data-1"))
+				setter([]byte("some-data-2"))
 
 				c := readFromReceiver(rx)
 				Eventually(c).Should(BeCalled(With(
@@ -268,7 +268,7 @@ var _ = Describe("v1 doppler server", func() {
 				defer close(done)
 				go func() {
 					for {
-						setter.Set([]byte("some-data"))
+						setter([]byte("some-data"))
 						select {
 						case <-done:
 							return
@@ -320,9 +320,9 @@ var _ = Describe("v1 doppler server", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 					setter := fetchSetter(mockRegistrar)
-					setter.Set([]byte("some-data-0"))
-					setter.Set([]byte("some-data-1"))
-					setter.Set([]byte("some-data-2"))
+					setter([]byte("some-data-0"))
+					setter([]byte("some-data-1"))
+					setter([]byte("some-data-2"))
 
 					c := readBatchFromReceiver(rx)
 					Eventually(c).Should(BeCalled(With([][]byte{
@@ -352,7 +352,7 @@ var _ = Describe("v1 doppler server", func() {
 
 					setter := fetchSetter(mockRegistrar)
 					for i := uint(0); i < (2*batchSize - 1); i++ {
-						setter.Set([]byte(fmt.Sprintf("some-data-%d", i)))
+						setter([]byte(fmt.Sprintf("some-data-%d", i)))
 					}
 
 					c := readBatchFromReceiver(rx)

--- a/src/code.cloudfoundry.org/loggregator/doppler/internal/grpcmanager/v1/envelope_traverser.gen.go
+++ b/src/code.cloudfoundry.org/loggregator/doppler/internal/grpcmanager/v1/envelope_traverser.gen.go
@@ -1,0 +1,1407 @@
+package v1
+
+import (
+	"hash/crc64"
+
+	"github.com/apoydence/pubsub"
+)
+
+func envelopeTraverserTraverse(data interface{}) pubsub.Paths {
+	return _AppID(data)
+}
+
+func done(data interface{}) pubsub.Paths {
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		return 0, nil, false
+	})
+}
+
+func hashBool(data bool) uint64 {
+	if data {
+		return 1
+	}
+	return 0
+}
+
+var tableECMA = crc64.MakeTable(crc64.ECMA)
+
+func _AppID(data interface{}) pubsub.Paths {
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 0,
+				pubsub.TreeTraverser(func(data interface{}) pubsub.Paths {
+					return __Envelope
+				}), true
+		case 1:
+			return crc64.Checksum([]byte(data.(*DataWrapper).AppID), tableECMA),
+				pubsub.TreeTraverser(func(data interface{}) pubsub.Paths {
+					return __Envelope
+				}), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+func __Envelope(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+	switch idx {
+
+	case 0:
+
+		if data.(*DataWrapper).Envelope == nil {
+			return 0, pubsub.TreeTraverser(done), true
+		}
+
+		return 1, pubsub.TreeTraverser(_Envelope_Ip), true
+
+	default:
+		return 0, nil, false
+	}
+}
+
+func _Envelope(data interface{}) pubsub.Paths {
+
+	if data.(*DataWrapper).Envelope == nil {
+		return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+			switch idx {
+			case 0:
+				return 0, pubsub.TreeTraverser(done), true
+			default:
+				return 0, nil, false
+			}
+		})
+	}
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 1, pubsub.TreeTraverser(_Envelope_Ip), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+func _Envelope_Ip(data interface{}) pubsub.Paths {
+
+	if data.(*DataWrapper).Envelope.Ip == nil {
+		return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+			switch idx {
+			case 0:
+				return 0,
+					pubsub.TreeTraverser(func(data interface{}) pubsub.Paths {
+						return __HttpStartStop_LogMessage_ValueMetric_CounterEvent_Error_ContainerMetric
+					}), true
+			default:
+				return 0, nil, false
+			}
+		})
+	}
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 0,
+				pubsub.TreeTraverser(func(data interface{}) pubsub.Paths {
+					return __HttpStartStop_LogMessage_ValueMetric_CounterEvent_Error_ContainerMetric
+				}), true
+		case 1:
+			return crc64.Checksum([]byte(*data.(*DataWrapper).Envelope.Ip), tableECMA),
+				pubsub.TreeTraverser(func(data interface{}) pubsub.Paths {
+					return __HttpStartStop_LogMessage_ValueMetric_CounterEvent_Error_ContainerMetric
+				}), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+func __HttpStartStop_LogMessage_ValueMetric_CounterEvent_Error_ContainerMetric(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+	switch idx {
+
+	case 0:
+
+		if data.(*DataWrapper).Envelope.HttpStartStop == nil {
+			return 0, pubsub.TreeTraverser(done), true
+		}
+
+		return 1, pubsub.TreeTraverser(_Envelope_HttpStartStop_RemoteAddress), true
+
+	case 1:
+
+		if data.(*DataWrapper).Envelope.LogMessage == nil {
+			return 0, pubsub.TreeTraverser(done), true
+		}
+
+		return 2, pubsub.TreeTraverser(_Envelope_LogMessage_SourceInstance), true
+
+	case 2:
+
+		if data.(*DataWrapper).Envelope.ValueMetric == nil {
+			return 0, pubsub.TreeTraverser(done), true
+		}
+
+		return 3, pubsub.TreeTraverser(_Envelope_ValueMetric_Name), true
+
+	case 3:
+
+		if data.(*DataWrapper).Envelope.CounterEvent == nil {
+			return 0, pubsub.TreeTraverser(done), true
+		}
+
+		return 4, pubsub.TreeTraverser(_Envelope_CounterEvent_Name), true
+
+	case 4:
+
+		if data.(*DataWrapper).Envelope.Error == nil {
+			return 0, pubsub.TreeTraverser(done), true
+		}
+
+		return 5, pubsub.TreeTraverser(_Envelope_Error_Source), true
+
+	case 5:
+
+		if data.(*DataWrapper).Envelope.ContainerMetric == nil {
+			return 0, pubsub.TreeTraverser(done), true
+		}
+
+		return 6, pubsub.TreeTraverser(_Envelope_ContainerMetric_ApplicationId), true
+
+	default:
+		return 0, nil, false
+	}
+}
+
+func _Envelope_HttpStartStop(data interface{}) pubsub.Paths {
+
+	if data.(*DataWrapper).Envelope.HttpStartStop == nil {
+		return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+			switch idx {
+			case 0:
+				return 0, pubsub.TreeTraverser(done), true
+			default:
+				return 0, nil, false
+			}
+		})
+	}
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 1, pubsub.TreeTraverser(_Envelope_HttpStartStop_RemoteAddress), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+func _Envelope_HttpStartStop_RemoteAddress(data interface{}) pubsub.Paths {
+
+	if data.(*DataWrapper).Envelope.HttpStartStop.RemoteAddress == nil {
+		return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+			switch idx {
+			case 0:
+				return 0, pubsub.TreeTraverser(_Envelope_HttpStartStop_UserAgent), true
+			default:
+				return 0, nil, false
+			}
+		})
+	}
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 0, pubsub.TreeTraverser(_Envelope_HttpStartStop_UserAgent), true
+		case 1:
+			return crc64.Checksum([]byte(*data.(*DataWrapper).Envelope.HttpStartStop.RemoteAddress), tableECMA), pubsub.TreeTraverser(_Envelope_HttpStartStop_UserAgent), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+func _Envelope_HttpStartStop_UserAgent(data interface{}) pubsub.Paths {
+
+	if data.(*DataWrapper).Envelope.HttpStartStop.UserAgent == nil {
+		return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+			switch idx {
+			case 0:
+				return 0, pubsub.TreeTraverser(_Envelope_HttpStartStop_StatusCode), true
+			default:
+				return 0, nil, false
+			}
+		})
+	}
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 0, pubsub.TreeTraverser(_Envelope_HttpStartStop_StatusCode), true
+		case 1:
+			return crc64.Checksum([]byte(*data.(*DataWrapper).Envelope.HttpStartStop.UserAgent), tableECMA), pubsub.TreeTraverser(_Envelope_HttpStartStop_StatusCode), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+func _Envelope_HttpStartStop_StatusCode(data interface{}) pubsub.Paths {
+
+	if data.(*DataWrapper).Envelope.HttpStartStop.StatusCode == nil {
+		return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+			switch idx {
+			case 0:
+				return 0, pubsub.TreeTraverser(_Envelope_HttpStartStop_ContentLength), true
+			default:
+				return 0, nil, false
+			}
+		})
+	}
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 0, pubsub.TreeTraverser(_Envelope_HttpStartStop_ContentLength), true
+		case 1:
+			return uint64(*data.(*DataWrapper).Envelope.HttpStartStop.StatusCode), pubsub.TreeTraverser(_Envelope_HttpStartStop_ContentLength), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+func _Envelope_HttpStartStop_ContentLength(data interface{}) pubsub.Paths {
+
+	if data.(*DataWrapper).Envelope.HttpStartStop.ContentLength == nil {
+		return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+			switch idx {
+			case 0:
+				return 0, pubsub.TreeTraverser(_Envelope_HttpStartStop_InstanceIndex), true
+			default:
+				return 0, nil, false
+			}
+		})
+	}
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 0, pubsub.TreeTraverser(_Envelope_HttpStartStop_InstanceIndex), true
+		case 1:
+			return uint64(*data.(*DataWrapper).Envelope.HttpStartStop.ContentLength), pubsub.TreeTraverser(_Envelope_HttpStartStop_InstanceIndex), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+func _Envelope_HttpStartStop_InstanceIndex(data interface{}) pubsub.Paths {
+
+	if data.(*DataWrapper).Envelope.HttpStartStop.InstanceIndex == nil {
+		return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+			switch idx {
+			case 0:
+				return 0, pubsub.TreeTraverser(_Envelope_HttpStartStop_InstanceId), true
+			default:
+				return 0, nil, false
+			}
+		})
+	}
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 0, pubsub.TreeTraverser(_Envelope_HttpStartStop_InstanceId), true
+		case 1:
+			return uint64(*data.(*DataWrapper).Envelope.HttpStartStop.InstanceIndex), pubsub.TreeTraverser(_Envelope_HttpStartStop_InstanceId), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+func _Envelope_HttpStartStop_InstanceId(data interface{}) pubsub.Paths {
+
+	if data.(*DataWrapper).Envelope.HttpStartStop.InstanceId == nil {
+		return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+			switch idx {
+			case 0:
+				return 0,
+					pubsub.TreeTraverser(func(data interface{}) pubsub.Paths {
+						return __ApplicationId
+					}), true
+			default:
+				return 0, nil, false
+			}
+		})
+	}
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 0,
+				pubsub.TreeTraverser(func(data interface{}) pubsub.Paths {
+					return __ApplicationId
+				}), true
+		case 1:
+			return crc64.Checksum([]byte(*data.(*DataWrapper).Envelope.HttpStartStop.InstanceId), tableECMA),
+				pubsub.TreeTraverser(func(data interface{}) pubsub.Paths {
+					return __ApplicationId
+				}), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+func __ApplicationId(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+	switch idx {
+
+	case 0:
+
+		if data.(*DataWrapper).Envelope.HttpStartStop.ApplicationId == nil {
+			return 0, pubsub.TreeTraverser(done), true
+		}
+
+		return 1, pubsub.TreeTraverser(_Envelope_HttpStartStop_ApplicationId_Low), true
+
+	default:
+		return 0, nil, false
+	}
+}
+
+func _Envelope_HttpStartStop_ApplicationId(data interface{}) pubsub.Paths {
+
+	if data.(*DataWrapper).Envelope.HttpStartStop.ApplicationId == nil {
+		return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+			switch idx {
+			case 0:
+				return 0, pubsub.TreeTraverser(done), true
+			default:
+				return 0, nil, false
+			}
+		})
+	}
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 1, pubsub.TreeTraverser(_Envelope_HttpStartStop_ApplicationId_Low), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+func _Envelope_HttpStartStop_ApplicationId_Low(data interface{}) pubsub.Paths {
+
+	if data.(*DataWrapper).Envelope.HttpStartStop.ApplicationId.Low == nil {
+		return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+			switch idx {
+			case 0:
+				return 0, pubsub.TreeTraverser(_Envelope_HttpStartStop_ApplicationId_High), true
+			default:
+				return 0, nil, false
+			}
+		})
+	}
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 0, pubsub.TreeTraverser(_Envelope_HttpStartStop_ApplicationId_High), true
+		case 1:
+			return *data.(*DataWrapper).Envelope.HttpStartStop.ApplicationId.Low, pubsub.TreeTraverser(_Envelope_HttpStartStop_ApplicationId_High), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+func _Envelope_HttpStartStop_ApplicationId_High(data interface{}) pubsub.Paths {
+
+	if data.(*DataWrapper).Envelope.HttpStartStop.ApplicationId.High == nil {
+		return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+			switch idx {
+			case 0:
+				return 0, pubsub.TreeTraverser(done), true
+			default:
+				return 0, nil, false
+			}
+		})
+	}
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 0, pubsub.TreeTraverser(done), true
+		case 1:
+			return *data.(*DataWrapper).Envelope.HttpStartStop.ApplicationId.High, pubsub.TreeTraverser(done), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+func _Envelope_LogMessage(data interface{}) pubsub.Paths {
+
+	if data.(*DataWrapper).Envelope.LogMessage == nil {
+		return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+			switch idx {
+			case 0:
+				return 0, pubsub.TreeTraverser(done), true
+			default:
+				return 0, nil, false
+			}
+		})
+	}
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 1, pubsub.TreeTraverser(_Envelope_LogMessage_SourceInstance), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+func _Envelope_LogMessage_SourceInstance(data interface{}) pubsub.Paths {
+
+	if data.(*DataWrapper).Envelope.LogMessage.SourceInstance == nil {
+		return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+			switch idx {
+			case 0:
+				return 0, pubsub.TreeTraverser(done), true
+			default:
+				return 0, nil, false
+			}
+		})
+	}
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 0, pubsub.TreeTraverser(done), true
+		case 1:
+			return crc64.Checksum([]byte(*data.(*DataWrapper).Envelope.LogMessage.SourceInstance), tableECMA), pubsub.TreeTraverser(done), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+func _Envelope_ValueMetric(data interface{}) pubsub.Paths {
+
+	if data.(*DataWrapper).Envelope.ValueMetric == nil {
+		return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+			switch idx {
+			case 0:
+				return 0, pubsub.TreeTraverser(done), true
+			default:
+				return 0, nil, false
+			}
+		})
+	}
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 1, pubsub.TreeTraverser(_Envelope_ValueMetric_Name), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+func _Envelope_ValueMetric_Name(data interface{}) pubsub.Paths {
+
+	if data.(*DataWrapper).Envelope.ValueMetric.Name == nil {
+		return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+			switch idx {
+			case 0:
+				return 0, pubsub.TreeTraverser(_Envelope_ValueMetric_Value), true
+			default:
+				return 0, nil, false
+			}
+		})
+	}
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 0, pubsub.TreeTraverser(_Envelope_ValueMetric_Value), true
+		case 1:
+			return crc64.Checksum([]byte(*data.(*DataWrapper).Envelope.ValueMetric.Name), tableECMA), pubsub.TreeTraverser(_Envelope_ValueMetric_Value), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+func _Envelope_ValueMetric_Value(data interface{}) pubsub.Paths {
+
+	if data.(*DataWrapper).Envelope.ValueMetric.Value == nil {
+		return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+			switch idx {
+			case 0:
+				return 0, pubsub.TreeTraverser(_Envelope_ValueMetric_Unit), true
+			default:
+				return 0, nil, false
+			}
+		})
+	}
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 0, pubsub.TreeTraverser(_Envelope_ValueMetric_Unit), true
+		case 1:
+			return uint64(*data.(*DataWrapper).Envelope.ValueMetric.Value), pubsub.TreeTraverser(_Envelope_ValueMetric_Unit), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+func _Envelope_ValueMetric_Unit(data interface{}) pubsub.Paths {
+
+	if data.(*DataWrapper).Envelope.ValueMetric.Unit == nil {
+		return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+			switch idx {
+			case 0:
+				return 0, pubsub.TreeTraverser(done), true
+			default:
+				return 0, nil, false
+			}
+		})
+	}
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 0, pubsub.TreeTraverser(done), true
+		case 1:
+			return crc64.Checksum([]byte(*data.(*DataWrapper).Envelope.ValueMetric.Unit), tableECMA), pubsub.TreeTraverser(done), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+func _Envelope_CounterEvent(data interface{}) pubsub.Paths {
+
+	if data.(*DataWrapper).Envelope.CounterEvent == nil {
+		return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+			switch idx {
+			case 0:
+				return 0, pubsub.TreeTraverser(done), true
+			default:
+				return 0, nil, false
+			}
+		})
+	}
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 1, pubsub.TreeTraverser(_Envelope_CounterEvent_Name), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+func _Envelope_CounterEvent_Name(data interface{}) pubsub.Paths {
+
+	if data.(*DataWrapper).Envelope.CounterEvent.Name == nil {
+		return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+			switch idx {
+			case 0:
+				return 0, pubsub.TreeTraverser(_Envelope_CounterEvent_Delta), true
+			default:
+				return 0, nil, false
+			}
+		})
+	}
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 0, pubsub.TreeTraverser(_Envelope_CounterEvent_Delta), true
+		case 1:
+			return crc64.Checksum([]byte(*data.(*DataWrapper).Envelope.CounterEvent.Name), tableECMA), pubsub.TreeTraverser(_Envelope_CounterEvent_Delta), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+func _Envelope_CounterEvent_Delta(data interface{}) pubsub.Paths {
+
+	if data.(*DataWrapper).Envelope.CounterEvent.Delta == nil {
+		return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+			switch idx {
+			case 0:
+				return 0, pubsub.TreeTraverser(_Envelope_CounterEvent_Total), true
+			default:
+				return 0, nil, false
+			}
+		})
+	}
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 0, pubsub.TreeTraverser(_Envelope_CounterEvent_Total), true
+		case 1:
+			return *data.(*DataWrapper).Envelope.CounterEvent.Delta, pubsub.TreeTraverser(_Envelope_CounterEvent_Total), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+func _Envelope_CounterEvent_Total(data interface{}) pubsub.Paths {
+
+	if data.(*DataWrapper).Envelope.CounterEvent.Total == nil {
+		return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+			switch idx {
+			case 0:
+				return 0, pubsub.TreeTraverser(done), true
+			default:
+				return 0, nil, false
+			}
+		})
+	}
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 0, pubsub.TreeTraverser(done), true
+		case 1:
+			return *data.(*DataWrapper).Envelope.CounterEvent.Total, pubsub.TreeTraverser(done), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+func _Envelope_Error(data interface{}) pubsub.Paths {
+
+	if data.(*DataWrapper).Envelope.Error == nil {
+		return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+			switch idx {
+			case 0:
+				return 0, pubsub.TreeTraverser(done), true
+			default:
+				return 0, nil, false
+			}
+		})
+	}
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 1, pubsub.TreeTraverser(_Envelope_Error_Source), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+func _Envelope_Error_Source(data interface{}) pubsub.Paths {
+
+	if data.(*DataWrapper).Envelope.Error.Source == nil {
+		return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+			switch idx {
+			case 0:
+				return 0, pubsub.TreeTraverser(_Envelope_Error_Code), true
+			default:
+				return 0, nil, false
+			}
+		})
+	}
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 0, pubsub.TreeTraverser(_Envelope_Error_Code), true
+		case 1:
+			return crc64.Checksum([]byte(*data.(*DataWrapper).Envelope.Error.Source), tableECMA), pubsub.TreeTraverser(_Envelope_Error_Code), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+func _Envelope_Error_Code(data interface{}) pubsub.Paths {
+
+	if data.(*DataWrapper).Envelope.Error.Code == nil {
+		return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+			switch idx {
+			case 0:
+				return 0, pubsub.TreeTraverser(_Envelope_Error_Message), true
+			default:
+				return 0, nil, false
+			}
+		})
+	}
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 0, pubsub.TreeTraverser(_Envelope_Error_Message), true
+		case 1:
+			return uint64(*data.(*DataWrapper).Envelope.Error.Code), pubsub.TreeTraverser(_Envelope_Error_Message), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+func _Envelope_Error_Message(data interface{}) pubsub.Paths {
+
+	if data.(*DataWrapper).Envelope.Error.Message == nil {
+		return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+			switch idx {
+			case 0:
+				return 0, pubsub.TreeTraverser(done), true
+			default:
+				return 0, nil, false
+			}
+		})
+	}
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 0, pubsub.TreeTraverser(done), true
+		case 1:
+			return crc64.Checksum([]byte(*data.(*DataWrapper).Envelope.Error.Message), tableECMA), pubsub.TreeTraverser(done), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+func _Envelope_ContainerMetric(data interface{}) pubsub.Paths {
+
+	if data.(*DataWrapper).Envelope.ContainerMetric == nil {
+		return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+			switch idx {
+			case 0:
+				return 0, pubsub.TreeTraverser(done), true
+			default:
+				return 0, nil, false
+			}
+		})
+	}
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 1, pubsub.TreeTraverser(_Envelope_ContainerMetric_ApplicationId), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+func _Envelope_ContainerMetric_ApplicationId(data interface{}) pubsub.Paths {
+
+	if data.(*DataWrapper).Envelope.ContainerMetric.ApplicationId == nil {
+		return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+			switch idx {
+			case 0:
+				return 0, pubsub.TreeTraverser(_Envelope_ContainerMetric_InstanceIndex), true
+			default:
+				return 0, nil, false
+			}
+		})
+	}
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 0, pubsub.TreeTraverser(_Envelope_ContainerMetric_InstanceIndex), true
+		case 1:
+			return crc64.Checksum([]byte(*data.(*DataWrapper).Envelope.ContainerMetric.ApplicationId), tableECMA), pubsub.TreeTraverser(_Envelope_ContainerMetric_InstanceIndex), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+func _Envelope_ContainerMetric_InstanceIndex(data interface{}) pubsub.Paths {
+
+	if data.(*DataWrapper).Envelope.ContainerMetric.InstanceIndex == nil {
+		return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+			switch idx {
+			case 0:
+				return 0, pubsub.TreeTraverser(_Envelope_ContainerMetric_CpuPercentage), true
+			default:
+				return 0, nil, false
+			}
+		})
+	}
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 0, pubsub.TreeTraverser(_Envelope_ContainerMetric_CpuPercentage), true
+		case 1:
+			return uint64(*data.(*DataWrapper).Envelope.ContainerMetric.InstanceIndex), pubsub.TreeTraverser(_Envelope_ContainerMetric_CpuPercentage), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+func _Envelope_ContainerMetric_CpuPercentage(data interface{}) pubsub.Paths {
+
+	if data.(*DataWrapper).Envelope.ContainerMetric.CpuPercentage == nil {
+		return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+			switch idx {
+			case 0:
+				return 0, pubsub.TreeTraverser(_Envelope_ContainerMetric_MemoryBytes), true
+			default:
+				return 0, nil, false
+			}
+		})
+	}
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 0, pubsub.TreeTraverser(_Envelope_ContainerMetric_MemoryBytes), true
+		case 1:
+			return uint64(*data.(*DataWrapper).Envelope.ContainerMetric.CpuPercentage), pubsub.TreeTraverser(_Envelope_ContainerMetric_MemoryBytes), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+func _Envelope_ContainerMetric_MemoryBytes(data interface{}) pubsub.Paths {
+
+	if data.(*DataWrapper).Envelope.ContainerMetric.MemoryBytes == nil {
+		return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+			switch idx {
+			case 0:
+				return 0, pubsub.TreeTraverser(_Envelope_ContainerMetric_DiskBytes), true
+			default:
+				return 0, nil, false
+			}
+		})
+	}
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 0, pubsub.TreeTraverser(_Envelope_ContainerMetric_DiskBytes), true
+		case 1:
+			return *data.(*DataWrapper).Envelope.ContainerMetric.MemoryBytes, pubsub.TreeTraverser(_Envelope_ContainerMetric_DiskBytes), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+func _Envelope_ContainerMetric_DiskBytes(data interface{}) pubsub.Paths {
+
+	if data.(*DataWrapper).Envelope.ContainerMetric.DiskBytes == nil {
+		return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+			switch idx {
+			case 0:
+				return 0, pubsub.TreeTraverser(_Envelope_ContainerMetric_MemoryBytesQuota), true
+			default:
+				return 0, nil, false
+			}
+		})
+	}
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 0, pubsub.TreeTraverser(_Envelope_ContainerMetric_MemoryBytesQuota), true
+		case 1:
+			return *data.(*DataWrapper).Envelope.ContainerMetric.DiskBytes, pubsub.TreeTraverser(_Envelope_ContainerMetric_MemoryBytesQuota), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+func _Envelope_ContainerMetric_MemoryBytesQuota(data interface{}) pubsub.Paths {
+
+	if data.(*DataWrapper).Envelope.ContainerMetric.MemoryBytesQuota == nil {
+		return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+			switch idx {
+			case 0:
+				return 0, pubsub.TreeTraverser(_Envelope_ContainerMetric_DiskBytesQuota), true
+			default:
+				return 0, nil, false
+			}
+		})
+	}
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 0, pubsub.TreeTraverser(_Envelope_ContainerMetric_DiskBytesQuota), true
+		case 1:
+			return *data.(*DataWrapper).Envelope.ContainerMetric.MemoryBytesQuota, pubsub.TreeTraverser(_Envelope_ContainerMetric_DiskBytesQuota), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+func _Envelope_ContainerMetric_DiskBytesQuota(data interface{}) pubsub.Paths {
+
+	if data.(*DataWrapper).Envelope.ContainerMetric.DiskBytesQuota == nil {
+		return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+			switch idx {
+			case 0:
+				return 0, pubsub.TreeTraverser(done), true
+			default:
+				return 0, nil, false
+			}
+		})
+	}
+
+	return pubsub.Paths(func(idx int, data interface{}) (path uint64, nextTraverser pubsub.TreeTraverser, ok bool) {
+		switch idx {
+		case 0:
+			return 0, pubsub.TreeTraverser(done), true
+		case 1:
+			return *data.(*DataWrapper).Envelope.ContainerMetric.DiskBytesQuota, pubsub.TreeTraverser(done), true
+		default:
+			return 0, nil, false
+		}
+	})
+}
+
+type DataWrapperFilter struct {
+	AppID    *string
+	Envelope *eventsEnvelopeFilter
+}
+
+type eventsEnvelopeFilter struct {
+	Ip              *string
+	HttpStartStop   *HttpStartStopFilter
+	LogMessage      *LogMessageFilter
+	ValueMetric     *ValueMetricFilter
+	CounterEvent    *CounterEventFilter
+	Error           *ErrorFilter
+	ContainerMetric *ContainerMetricFilter
+}
+
+type HttpStartStopFilter struct {
+	RemoteAddress *string
+	UserAgent     *string
+	StatusCode    *int32
+	ContentLength *int64
+	InstanceIndex *int32
+	InstanceId    *string
+	ApplicationId *UUIDFilter
+}
+
+type UUIDFilter struct {
+	Low  *uint64
+	High *uint64
+}
+
+type LogMessageFilter struct {
+	SourceInstance *string
+}
+
+type ValueMetricFilter struct {
+	Name  *string
+	Value *float64
+	Unit  *string
+}
+
+type CounterEventFilter struct {
+	Name  *string
+	Delta *uint64
+	Total *uint64
+}
+
+type ErrorFilter struct {
+	Source  *string
+	Code    *int32
+	Message *string
+}
+
+type ContainerMetricFilter struct {
+	ApplicationId    *string
+	InstanceIndex    *int32
+	CpuPercentage    *float64
+	MemoryBytes      *uint64
+	DiskBytes        *uint64
+	MemoryBytesQuota *uint64
+	DiskBytesQuota   *uint64
+}
+
+func envelopeTraverserCreatePath(f *DataWrapperFilter) []uint64 {
+	if f == nil {
+		return nil
+	}
+	var path []uint64
+
+	var count int
+	if f.Envelope != nil {
+		count++
+	}
+
+	if count > 1 {
+		panic("Only one field can be set")
+	}
+
+	if f.AppID != nil {
+		path = append(path, crc64.Checksum([]byte(*f.AppID), tableECMA))
+	} else {
+		path = append(path, 0)
+	}
+
+	path = append(path, createPath_Envelope(f.Envelope)...)
+
+	for i := len(path) - 1; i >= 1; i-- {
+		if path[i] != 0 {
+			break
+		}
+		path = path[:i]
+	}
+
+	return path
+}
+
+func createPath_Envelope(f *eventsEnvelopeFilter) []uint64 {
+	if f == nil {
+		return nil
+	}
+	var path []uint64
+
+	path = append(path, 1)
+
+	var count int
+	if f.HttpStartStop != nil {
+		count++
+	}
+
+	if f.LogMessage != nil {
+		count++
+	}
+
+	if f.ValueMetric != nil {
+		count++
+	}
+
+	if f.CounterEvent != nil {
+		count++
+	}
+
+	if f.Error != nil {
+		count++
+	}
+
+	if f.ContainerMetric != nil {
+		count++
+	}
+
+	if count > 1 {
+		panic("Only one field can be set")
+	}
+
+	if f.Ip != nil {
+		path = append(path, crc64.Checksum([]byte(*f.Ip), tableECMA))
+	} else {
+		path = append(path, 0)
+	}
+
+	path = append(path, createPath_HttpStartStop(f.HttpStartStop)...)
+
+	path = append(path, createPath_LogMessage(f.LogMessage)...)
+
+	path = append(path, createPath_ValueMetric(f.ValueMetric)...)
+
+	path = append(path, createPath_CounterEvent(f.CounterEvent)...)
+
+	path = append(path, createPath_Error(f.Error)...)
+
+	path = append(path, createPath_ContainerMetric(f.ContainerMetric)...)
+
+	return path
+}
+
+func createPath_HttpStartStop(f *HttpStartStopFilter) []uint64 {
+	if f == nil {
+		return nil
+	}
+	var path []uint64
+
+	path = append(path, 1)
+
+	var count int
+	if f.ApplicationId != nil {
+		count++
+	}
+
+	if count > 1 {
+		panic("Only one field can be set")
+	}
+
+	if f.RemoteAddress != nil {
+		path = append(path, crc64.Checksum([]byte(*f.RemoteAddress), tableECMA))
+	} else {
+		path = append(path, 0)
+	}
+
+	if f.UserAgent != nil {
+		path = append(path, crc64.Checksum([]byte(*f.UserAgent), tableECMA))
+	} else {
+		path = append(path, 0)
+	}
+
+	if f.StatusCode != nil {
+		path = append(path, uint64(*f.StatusCode))
+	} else {
+		path = append(path, 0)
+	}
+
+	if f.ContentLength != nil {
+		path = append(path, uint64(*f.ContentLength))
+	} else {
+		path = append(path, 0)
+	}
+
+	if f.InstanceIndex != nil {
+		path = append(path, uint64(*f.InstanceIndex))
+	} else {
+		path = append(path, 0)
+	}
+
+	if f.InstanceId != nil {
+		path = append(path, crc64.Checksum([]byte(*f.InstanceId), tableECMA))
+	} else {
+		path = append(path, 0)
+	}
+
+	path = append(path, createPath_ApplicationId(f.ApplicationId)...)
+
+	return path
+}
+
+func createPath_ApplicationId(f *UUIDFilter) []uint64 {
+	if f == nil {
+		return nil
+	}
+	var path []uint64
+
+	path = append(path, 1)
+
+	var count int
+	if count > 1 {
+		panic("Only one field can be set")
+	}
+
+	if f.Low != nil {
+		path = append(path, *f.Low)
+	} else {
+		path = append(path, 0)
+	}
+
+	if f.High != nil {
+		path = append(path, *f.High)
+	} else {
+		path = append(path, 0)
+	}
+
+	return path
+}
+
+func createPath_LogMessage(f *LogMessageFilter) []uint64 {
+	if f == nil {
+		return nil
+	}
+	var path []uint64
+
+	path = append(path, 2)
+
+	var count int
+	if count > 1 {
+		panic("Only one field can be set")
+	}
+
+	if f.SourceInstance != nil {
+		path = append(path, crc64.Checksum([]byte(*f.SourceInstance), tableECMA))
+	} else {
+		path = append(path, 0)
+	}
+
+	return path
+}
+
+func createPath_ValueMetric(f *ValueMetricFilter) []uint64 {
+	if f == nil {
+		return nil
+	}
+	var path []uint64
+
+	path = append(path, 3)
+
+	var count int
+	if count > 1 {
+		panic("Only one field can be set")
+	}
+
+	if f.Name != nil {
+		path = append(path, crc64.Checksum([]byte(*f.Name), tableECMA))
+	} else {
+		path = append(path, 0)
+	}
+
+	if f.Value != nil {
+		path = append(path, uint64(*f.Value))
+	} else {
+		path = append(path, 0)
+	}
+
+	if f.Unit != nil {
+		path = append(path, crc64.Checksum([]byte(*f.Unit), tableECMA))
+	} else {
+		path = append(path, 0)
+	}
+
+	return path
+}
+
+func createPath_CounterEvent(f *CounterEventFilter) []uint64 {
+	if f == nil {
+		return nil
+	}
+	var path []uint64
+
+	path = append(path, 4)
+
+	var count int
+	if count > 1 {
+		panic("Only one field can be set")
+	}
+
+	if f.Name != nil {
+		path = append(path, crc64.Checksum([]byte(*f.Name), tableECMA))
+	} else {
+		path = append(path, 0)
+	}
+
+	if f.Delta != nil {
+		path = append(path, *f.Delta)
+	} else {
+		path = append(path, 0)
+	}
+
+	if f.Total != nil {
+		path = append(path, *f.Total)
+	} else {
+		path = append(path, 0)
+	}
+
+	return path
+}
+
+func createPath_Error(f *ErrorFilter) []uint64 {
+	if f == nil {
+		return nil
+	}
+	var path []uint64
+
+	path = append(path, 5)
+
+	var count int
+	if count > 1 {
+		panic("Only one field can be set")
+	}
+
+	if f.Source != nil {
+		path = append(path, crc64.Checksum([]byte(*f.Source), tableECMA))
+	} else {
+		path = append(path, 0)
+	}
+
+	if f.Code != nil {
+		path = append(path, uint64(*f.Code))
+	} else {
+		path = append(path, 0)
+	}
+
+	if f.Message != nil {
+		path = append(path, crc64.Checksum([]byte(*f.Message), tableECMA))
+	} else {
+		path = append(path, 0)
+	}
+
+	return path
+}
+
+func createPath_ContainerMetric(f *ContainerMetricFilter) []uint64 {
+	if f == nil {
+		return nil
+	}
+	var path []uint64
+
+	path = append(path, 6)
+
+	var count int
+	if count > 1 {
+		panic("Only one field can be set")
+	}
+
+	if f.ApplicationId != nil {
+		path = append(path, crc64.Checksum([]byte(*f.ApplicationId), tableECMA))
+	} else {
+		path = append(path, 0)
+	}
+
+	if f.InstanceIndex != nil {
+		path = append(path, uint64(*f.InstanceIndex))
+	} else {
+		path = append(path, 0)
+	}
+
+	if f.CpuPercentage != nil {
+		path = append(path, uint64(*f.CpuPercentage))
+	} else {
+		path = append(path, 0)
+	}
+
+	if f.MemoryBytes != nil {
+		path = append(path, *f.MemoryBytes)
+	} else {
+		path = append(path, 0)
+	}
+
+	if f.DiskBytes != nil {
+		path = append(path, *f.DiskBytes)
+	} else {
+		path = append(path, 0)
+	}
+
+	if f.MemoryBytesQuota != nil {
+		path = append(path, *f.MemoryBytesQuota)
+	} else {
+		path = append(path, 0)
+	}
+
+	if f.DiskBytesQuota != nil {
+		path = append(path, *f.DiskBytesQuota)
+	} else {
+		path = append(path, 0)
+	}
+
+	return path
+}

--- a/src/code.cloudfoundry.org/loggregator/doppler/internal/grpcmanager/v1/router_benchmark_test.go
+++ b/src/code.cloudfoundry.org/loggregator/doppler/internal/grpcmanager/v1/router_benchmark_test.go
@@ -1,0 +1,83 @@
+package v1_test
+
+import (
+	"crypto/rand"
+	"fmt"
+	"os"
+	"testing"
+
+	"code.cloudfoundry.org/loggregator/doppler/internal/grpcmanager/v1"
+	"code.cloudfoundry.org/loggregator/plumbing"
+	"github.com/cloudfoundry/sonde-go/events"
+	"github.com/gogo/protobuf/proto"
+)
+
+var (
+	gen func() *events.Envelope
+	r   *v1.Router
+)
+
+const numOfSubs = 100000
+
+func TestMain(m *testing.M) {
+	gen = randEnvGen()
+
+	r = v1.NewRouter()
+	setter := NopSetter{}
+
+	for i := 0; i < numOfSubs; i++ {
+		r.Register(&plumbing.SubscriptionRequest{Filter: &plumbing.Filter{
+			AppID:   fmt.Sprintf("%d", i%20000),
+			Message: &plumbing.Filter_Log{&plumbing.LogFilter{}},
+		}}, setter)
+	}
+
+	os.Exit(m.Run())
+}
+
+func BenchmarkDopplerRouter(b *testing.B) {
+	defer b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		e := gen()
+		r.SendTo(e.GetLogMessage().GetAppId(), e)
+	}
+}
+
+type NopSetter struct{}
+
+func (s NopSetter) Set(data []byte) {}
+
+func randEnvGen() func() *events.Envelope {
+	var s []*events.Envelope
+	for i := 0; i < 100; i++ {
+		buf := make([]byte, 10)
+		rand.Read(buf)
+		s = append(s, buildLog(fmt.Sprintf("%d", i%20000), buf))
+	}
+
+	var i int
+	return func() *events.Envelope {
+		i++
+		return s[i%len(s)]
+	}
+}
+
+func buildLog(appID string, payload []byte) *events.Envelope {
+	return &events.Envelope{
+		Origin:     proto.String("some-origin"),
+		EventType:  events.Envelope_LogMessage.Enum(),
+		Deployment: proto.String("some-deployment"),
+		Job:        proto.String("some-job"),
+		Index:      proto.String("some-index"),
+		Ip:         proto.String("some-ip"),
+		LogMessage: &events.LogMessage{
+			Message:        payload,
+			MessageType:    events.LogMessage_OUT.Enum(),
+			Timestamp:      proto.Int64(99),
+			AppId:          proto.String(appID),
+			SourceType:     proto.String("test-source-type"),
+			SourceInstance: proto.String("test-source-instance"),
+		},
+	}
+}

--- a/src/code.cloudfoundry.org/loggregator/doppler/internal/grpcmanager/v1/router_benchmark_test.go
+++ b/src/code.cloudfoundry.org/loggregator/doppler/internal/grpcmanager/v1/router_benchmark_test.go
@@ -1,10 +1,11 @@
 package v1_test
 
 import (
-	"crypto/rand"
 	"fmt"
+	"math/rand"
 	"os"
 	"testing"
+	"time"
 
 	"code.cloudfoundry.org/loggregator/doppler/internal/grpcmanager/v1"
 	"code.cloudfoundry.org/loggregator/plumbing"
@@ -29,7 +30,7 @@ func TestMain(m *testing.M) {
 		r.Register(&plumbing.SubscriptionRequest{Filter: &plumbing.Filter{
 			AppID:   fmt.Sprintf("%d", i%20000),
 			Message: &plumbing.Filter_Log{&plumbing.LogFilter{}},
-		}}, setter)
+		}}, setter.Set)
 	}
 
 	os.Exit(m.Run())
@@ -71,10 +72,11 @@ func buildLog(appID string, payload []byte) *events.Envelope {
 		Job:        proto.String("some-job"),
 		Index:      proto.String("some-index"),
 		Ip:         proto.String("some-ip"),
+		Timestamp:  proto.Int64(time.Now().UnixNano()),
 		LogMessage: &events.LogMessage{
 			Message:        payload,
 			MessageType:    events.LogMessage_OUT.Enum(),
-			Timestamp:      proto.Int64(99),
+			Timestamp:      proto.Int64(time.Now().UnixNano()),
 			AppId:          proto.String(appID),
 			SourceType:     proto.String("test-source-type"),
 			SourceInstance: proto.String("test-source-instance"),

--- a/src/code.cloudfoundry.org/loggregator/doppler/internal/grpcmanager/v1/router_test.go
+++ b/src/code.cloudfoundry.org/loggregator/doppler/internal/grpcmanager/v1/router_test.go
@@ -1,6 +1,8 @@
 package v1_test
 
 import (
+	"time"
+
 	"code.cloudfoundry.org/loggregator/plumbing"
 
 	"code.cloudfoundry.org/loggregator/doppler/internal/grpcmanager/v1"
@@ -14,10 +16,20 @@ import (
 
 var _ = Describe("Router", func() {
 	var (
-		counterEnvelope      *events.Envelope
-		logEnvelope          *events.Envelope
-		counterEnvelopeBytes []byte
-		logEnvelopeBytes     []byte
+		counterEnvelope       *events.Envelope
+		logEnvelope1          *events.Envelope
+		logEnvelope2          *events.Envelope
+		httpStartStop1        *events.Envelope
+		httpStartStop2        *events.Envelope
+		containerMetric1      *events.Envelope
+		containerMetric2      *events.Envelope
+		counterEnvelopeBytes  []byte
+		logEnvelopeBytes1     []byte
+		logEnvelopeBytes2     []byte
+		httpStartStopBytes1   []byte
+		httpStartStopBytes2   []byte
+		containerMetricBytes1 []byte
+		containerMetricBytes2 []byte
 
 		router *v1.Router
 	)
@@ -26,17 +38,121 @@ var _ = Describe("Router", func() {
 		counterEnvelope = &events.Envelope{
 			Origin:    proto.String("some-origin"),
 			EventType: events.Envelope_CounterEvent.Enum(),
+			CounterEvent: &events.CounterEvent{
+				Name:  proto.String("some-name"),
+				Total: proto.Uint64(99),
+				Delta: proto.Uint64(101),
+			},
 		}
 
-		logEnvelope = &events.Envelope{
+		logEnvelope1 = &events.Envelope{
 			Origin:    proto.String("some-origin"),
+			Timestamp: proto.Int64(time.Now().UnixNano()),
 			EventType: events.Envelope_LogMessage.Enum(),
+			LogMessage: &events.LogMessage{
+				Timestamp:   proto.Int64(time.Now().UnixNano()),
+				Message:     []byte("some-message"),
+				MessageType: events.LogMessage_OUT.Enum(),
+				AppId:       proto.String("some-app-id"),
+			},
 		}
+
+		logEnvelope2 = &events.Envelope{
+			Origin:    proto.String("some-origin"),
+			Timestamp: proto.Int64(time.Now().UnixNano()),
+			EventType: events.Envelope_LogMessage.Enum(),
+			LogMessage: &events.LogMessage{
+				Timestamp:   proto.Int64(time.Now().UnixNano()),
+				Message:     []byte("some-message"),
+				MessageType: events.LogMessage_OUT.Enum(),
+				AppId:       proto.String("some-other-app-id"),
+			},
+		}
+
+		httpStartStop1 = &events.Envelope{
+			Origin:    proto.String("some-origin"),
+			Timestamp: proto.Int64(time.Now().UnixNano()),
+			EventType: events.Envelope_HttpStartStop.Enum(),
+			HttpStartStop: &events.HttpStartStop{
+				StartTimestamp: proto.Int64(time.Now().UnixNano()),
+				StopTimestamp:  proto.Int64(time.Now().UnixNano()),
+				RequestId:      &events.UUID{Low: proto.Uint64(0), High: proto.Uint64(0)},
+				PeerType:       events.PeerType_Client.Enum(),
+				Method:         events.Method_GET.Enum(),
+				Uri:            proto.String("some-uri"),
+				RemoteAddress:  proto.String("some-addr"),
+				UserAgent:      proto.String("some-user-agent"),
+				StatusCode:     proto.Int32(200),
+				ContentLength:  proto.Int64(100),
+				ApplicationId:  &events.UUID{Low: proto.Uint64(5), High: proto.Uint64(6)},
+			},
+		}
+
+		httpStartStop2 = &events.Envelope{
+			Origin:    proto.String("some-origin"),
+			Timestamp: proto.Int64(time.Now().UnixNano()),
+			EventType: events.Envelope_HttpStartStop.Enum(),
+			HttpStartStop: &events.HttpStartStop{
+				StartTimestamp: proto.Int64(time.Now().UnixNano()),
+				StopTimestamp:  proto.Int64(time.Now().UnixNano()),
+				RequestId:      &events.UUID{Low: proto.Uint64(0), High: proto.Uint64(0)},
+				PeerType:       events.PeerType_Client.Enum(),
+				Method:         events.Method_GET.Enum(),
+				Uri:            proto.String("some-uri"),
+				RemoteAddress:  proto.String("some-addr"),
+				UserAgent:      proto.String("some-user-agent"),
+				StatusCode:     proto.Int32(200),
+				ContentLength:  proto.Int64(100),
+				ApplicationId:  &events.UUID{Low: proto.Uint64(6), High: proto.Uint64(7)},
+			},
+		}
+
+		containerMetric1 = &events.Envelope{
+			Origin:    proto.String("some-origin"),
+			Timestamp: proto.Int64(time.Now().UnixNano()),
+			EventType: events.Envelope_ContainerMetric.Enum(),
+			ContainerMetric: &events.ContainerMetric{
+				ApplicationId: proto.String("05000000-0000-0000-0600-000000000000"),
+				InstanceIndex: proto.Int32(99),
+				CpuPercentage: proto.Float64(99),
+				MemoryBytes:   proto.Uint64(99),
+				DiskBytes:     proto.Uint64(99),
+			},
+		}
+
+		containerMetric2 = &events.Envelope{
+			Origin:    proto.String("some-origin"),
+			Timestamp: proto.Int64(time.Now().UnixNano()),
+			EventType: events.Envelope_ContainerMetric.Enum(),
+			ContainerMetric: &events.ContainerMetric{
+				ApplicationId: proto.String("06000000-0000-0000-0700-000000000000"),
+				InstanceIndex: proto.Int32(99),
+				CpuPercentage: proto.Float64(99),
+				MemoryBytes:   proto.Uint64(99),
+				DiskBytes:     proto.Uint64(99),
+			},
+		}
+
 		var err error
 		counterEnvelopeBytes, err = counterEnvelope.Marshal()
 		Expect(err).ToNot(HaveOccurred())
 
-		logEnvelopeBytes, err = logEnvelope.Marshal()
+		logEnvelopeBytes1, err = logEnvelope1.Marshal()
+		Expect(err).ToNot(HaveOccurred())
+
+		logEnvelopeBytes2, err = logEnvelope2.Marshal()
+		Expect(err).ToNot(HaveOccurred())
+
+		httpStartStopBytes1, err = httpStartStop1.Marshal()
+		Expect(err).ToNot(HaveOccurred())
+
+		httpStartStopBytes2, err = httpStartStop2.Marshal()
+		Expect(err).ToNot(HaveOccurred())
+
+		containerMetricBytes1, err = containerMetric1.Marshal()
+		Expect(err).ToNot(HaveOccurred())
+
+		containerMetricBytes2, err = containerMetric2.Marshal()
 		Expect(err).ToNot(HaveOccurred())
 
 		router = v1.NewRouter()
@@ -75,11 +191,11 @@ var _ = Describe("Router", func() {
 		})
 
 		It("receives all messages", func() {
-			router.SendTo("some-app-id", logEnvelope)
+			router.SendTo("some-app-id", logEnvelope1)
 			router.SendTo("some-app-id", counterEnvelope)
 
 			Expect(singleFirehoseSubscription.SetInput).To(
-				BeCalled(With(logEnvelopeBytes)),
+				BeCalled(With(logEnvelopeBytes1)),
 			)
 			Expect(singleFirehoseSubscription.SetInput).To(
 				BeCalled(With(counterEnvelopeBytes)),
@@ -88,7 +204,7 @@ var _ = Describe("Router", func() {
 
 		Context("when there are two subscriptions with the same ID", func() {
 			It("sends the message to one subscription", func() {
-				router.SendTo("some-app-id", logEnvelope)
+				router.SendTo("some-app-id", logEnvelope1)
 				combinedLen := len(multipleFirehoseOfSameSubscription[0].SetCalled) + len(multipleFirehoseOfSameSubscription[1].SetCalled)
 
 				Expect(combinedLen).To(Equal(1))
@@ -162,18 +278,18 @@ var _ = Describe("Router", func() {
 		})
 
 		It("sends a message to all subscriptions of the same app id", func() {
-			router.SendTo("some-app-id", counterEnvelope)
+			router.SendTo("some-app-id", logEnvelope1)
 
 			Expect(streamsForAppA[0].SetInput).To(
-				BeCalled(With(counterEnvelopeBytes)),
+				BeCalled(With(logEnvelopeBytes1)),
 			)
 			Expect(streamsForAppA[1].SetInput).To(
-				BeCalled(With(counterEnvelopeBytes)),
+				BeCalled(With(logEnvelopeBytes1)),
 			)
 		})
 
 		It("sends the envelope to a subscription only once", func() {
-			router.SendTo("some-other-app-id", counterEnvelope)
+			router.SendTo("some-other-app-id", logEnvelope2)
 
 			Expect(streamForAppB.SetCalled).To(
 				HaveLen(1),
@@ -190,7 +306,7 @@ var _ = Describe("Router", func() {
 		})
 
 		It("does not send the message to a subscription of a different app id", func() {
-			router.SendTo("some-app-id", counterEnvelope)
+			router.SendTo("some-app-id", logEnvelope1)
 
 			Expect(streamForAppB.SetInput).To(
 				Not(BeCalled()),
@@ -226,10 +342,10 @@ var _ = Describe("Router", func() {
 				Not(BeCalled()),
 			)
 
-			router.SendTo("some-app-id", logEnvelope)
+			router.SendTo("some-app-id", logEnvelope1)
 
 			Expect(streamWithLogFilter.SetInput).To(
-				BeCalled(With(logEnvelopeBytes)),
+				BeCalled(With(logEnvelopeBytes1)),
 			)
 		})
 	})
@@ -255,7 +371,7 @@ var _ = Describe("Router", func() {
 		})
 
 		It("sends only metric messages", func() {
-			router.SendTo("some-app-id", logEnvelope)
+			router.SendTo("some-app-id", logEnvelope1)
 
 			Expect(stream.SetCalled).To(
 				Not(BeCalled()),

--- a/src/code.cloudfoundry.org/loggregator/doppler/internal/grpcmanager/v1/v1_suite_test.go
+++ b/src/code.cloudfoundry.org/loggregator/doppler/internal/grpcmanager/v1/v1_suite_test.go
@@ -1,5 +1,3 @@
-//go:generate hel
-
 package v1_test
 
 import (


### PR DESCRIPTION
This simplifies the doppler/routing.

Benchmarks:

```
~/w/l/s/c/l/d/i/test (pubsub →↩☡) go test -bench=. -run=NoTest
testing: warning: no tests to run
BenchmarkPubSub-8          	  100000	     49353 ns/op	    4095 B/op	      99 allocs/op
BenchmarkDopplerRouter-8   	  200000	    119363 ns/op	     161 B/op	       1 allocs/op
PASS
ok  	code.cloudfoundry.org/loggregator/doppler/internal/test	30.061s
~/w/l/s/c/l/d/i/test (pubsub →↩☡) go test -bench=. -run=NoTest
testing: warning: no tests to run
BenchmarkPubSub-8          	  100000	     52136 ns/op	    4502 B/op	     105 allocs/op
BenchmarkDopplerRouter-8   	  200000	    117161 ns/op	     176 B/op	       1 allocs/op
PASS
ok  	code.cloudfoundry.org/loggregator/doppler/internal/test	29.691s
~/w/l/s/c/l/d/i/test (pubsub →↩☡) go test -bench=. -run=NoTest
testing: warning: no tests to run
BenchmarkPubSub-8          	  100000	     49762 ns/op	    4315 B/op	     102 allocs/op
BenchmarkDopplerRouter-8   	  200000	    116671 ns/op	     179 B/op	       1 allocs/op
PASS
ok  	code.cloudfoundry.org/loggregator/doppler/internal/test	29.540s
```