### PR TITLE
Cleanup exported constants in TC auth package

### DIFF
--- a/src/code.cloudfoundry.org/loggregator/trafficcontroller/internal/auth/accesslog.go
+++ b/src/code.cloudfoundry.org/loggregator/trafficcontroller/internal/auth/accesslog.go
@@ -12,7 +12,7 @@ import (
 	"time"
 )
 
-const REQUEST_ID_HEADER = "X-Vcap-Request-ID"
+const requestIDHeader = "X-Vcap-Request-ID"
 
 var logTemplate *template.Template
 
@@ -44,7 +44,7 @@ func NewAccessLog(req *http.Request, ts time.Time, host string, port uint32) *Ac
 }
 
 func (al *AccessLog) String() string {
-	vcapRequestId := al.request.Header.Get(REQUEST_ID_HEADER)
+	vcapRequestId := al.request.Header.Get(requestIDHeader)
 	path := al.request.URL.Path
 	if al.request.URL.RawQuery != "" {
 		path = fmt.Sprintf("%s?%s", al.request.URL.Path, al.request.URL.RawQuery)

--- a/src/code.cloudfoundry.org/loggregator/trafficcontroller/internal/auth/admin_access_authorizer.go
+++ b/src/code.cloudfoundry.org/loggregator/trafficcontroller/internal/auth/admin_access_authorizer.go
@@ -1,13 +1,14 @@
 package auth
 
 import (
-	"errors"
 	"log"
 	"strings"
 )
 
-const LOGGREGATOR_ADMIN_ROLE = "doppler.firehose"
-const BEARER_PREFIX = "bearer "
+const (
+	loggregatorAdminRole = "doppler.firehose"
+	bearerPrefix         = "bearer "
+)
 
 type AdminAccessAuthorizer func(authToken string) (bool, error)
 
@@ -23,20 +24,20 @@ func NewAdminAccessAuthorizer(disableAccessControl bool, client UaaClient) Admin
 
 	isAccessAllowed := func(authToken string) (bool, error) {
 		if authToken == "" {
-			return false, errors.New(NO_AUTH_TOKEN_PROVIDED_ERROR_MESSAGE)
+			return false, ErrNoAuthTokenProvided
 		}
 
-		authData, err := client.GetAuthData(strings.TrimPrefix(authToken, BEARER_PREFIX))
+		authData, err := client.GetAuthData(strings.TrimPrefix(authToken, bearerPrefix))
 
 		if err != nil {
 			log.Printf("Error getting auth data: %s", err)
-			return false, errors.New(INVALID_AUTH_TOKEN_ERROR_MESSAGE)
+			return false, ErrInvalidAuthToken
 		}
 
-		if authData.HasPermission(LOGGREGATOR_ADMIN_ROLE) {
+		if authData.HasPermission(loggregatorAdminRole) {
 			return true, nil
 		} else {
-			return false, errors.New(INVALID_AUTH_TOKEN_ERROR_MESSAGE)
+			return false, ErrInvalidAuthToken
 		}
 	}
 

--- a/src/code.cloudfoundry.org/loggregator/trafficcontroller/internal/auth/admin_access_authorizer_test.go
+++ b/src/code.cloudfoundry.org/loggregator/trafficcontroller/internal/auth/admin_access_authorizer_test.go
@@ -58,7 +58,7 @@ var _ = Describe("AdminAccessAuthorizer", func() {
 			authorized, err := authorizer("")
 
 			Expect(authorized).To(BeFalse())
-			Expect(err).To(Equal(errors.New(auth.NO_AUTH_TOKEN_PROVIDED_ERROR_MESSAGE)))
+			Expect(err).To(MatchError(auth.ErrNoAuthTokenProvided))
 		})
 	})
 
@@ -83,7 +83,7 @@ var _ = Describe("AdminAccessAuthorizer", func() {
 
 			authorized, err := authorizer(authToken)
 			Expect(authorized).To(BeFalse())
-			Expect(err).To(Equal(errors.New(auth.INVALID_AUTH_TOKEN_ERROR_MESSAGE)))
+			Expect(err).To(MatchError(auth.ErrInvalidAuthToken))
 
 			Expect(client.UsedToken).To(Equal("my-token"))
 		})
@@ -96,7 +96,7 @@ var _ = Describe("AdminAccessAuthorizer", func() {
 
 			authorized, err := authorizer(authToken)
 			Expect(authorized).To(BeFalse())
-			Expect(err).To(Equal(errors.New(auth.INVALID_AUTH_TOKEN_ERROR_MESSAGE)))
+			Expect(err).To(MatchError(auth.ErrInvalidAuthToken))
 
 			Expect(client.UsedToken).To(Equal("my-token"))
 		})

--- a/src/code.cloudfoundry.org/loggregator/trafficcontroller/internal/auth/log_access_authorizer.go
+++ b/src/code.cloudfoundry.org/loggregator/trafficcontroller/internal/auth/log_access_authorizer.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 )
 
-const (
-	NO_AUTH_TOKEN_PROVIDED_ERROR_MESSAGE = "Error: Authorization not provided"
-	INVALID_AUTH_TOKEN_ERROR_MESSAGE     = "Error: Invalid authorization"
+var (
+	ErrNoAuthTokenProvided = errors.New("Error: Authorization not provided")
+	ErrInvalidAuthToken    = errors.New("Error: Invalid authorization")
 )
 
 // TODO: We don't need to return an error and a status code. One will suffice.
@@ -25,8 +25,8 @@ func NewLogAccessAuthorizer(c *http.Client, disableAccessControl bool, apiHost s
 
 	return LogAccessAuthorizer(func(authToken string, target string) (int, error) {
 		if authToken == "" {
-			log.Printf(NO_AUTH_TOKEN_PROVIDED_ERROR_MESSAGE)
-			return http.StatusUnauthorized, errors.New(NO_AUTH_TOKEN_PROVIDED_ERROR_MESSAGE)
+			log.Println(ErrNoAuthTokenProvided)
+			return http.StatusUnauthorized, ErrNoAuthTokenProvided
 		}
 
 		req, _ := http.NewRequest("GET", apiHost+"/internal/v4/log_access/"+target, nil)

--- a/src/code.cloudfoundry.org/loggregator/trafficcontroller/internal/auth/log_access_authorizer_test.go
+++ b/src/code.cloudfoundry.org/loggregator/trafficcontroller/internal/auth/log_access_authorizer_test.go
@@ -2,7 +2,6 @@ package auth_test
 
 import (
 	"crypto/tls"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -54,7 +53,7 @@ var _ = Describe("LogAccessAuthorizer", func() {
 
 			status, err := authorizer("", "myAppId")
 			Expect(status).To(Equal(http.StatusUnauthorized))
-			Expect(err).To(Equal(errors.New(auth.NO_AUTH_TOKEN_PROVIDED_ERROR_MESSAGE)))
+			Expect(err).To(MatchError(auth.ErrNoAuthTokenProvided))
 		})
 
 		It("allows access when the api returns 200, and otherwise denies access", func() {


### PR DESCRIPTION
* Pre build errors to prevent high memory usage in high load situation
* Do not export constants/variables that do not need to be exported