### PR TITLE
Add default cc.tls_port to the loggregator_trafficcontroller

### DIFF
--- a/jobs/loggregator_trafficcontroller/spec
+++ b/jobs/loggregator_trafficcontroller/spec
@@ -121,6 +121,7 @@ properties:
     description: "Internal hostname used to resolve the address of the Cloud Controller"
   cc.tls_port:
     description: "Port for internal TLS communication"
+    default: 9023
   cc.mutual_tls.ca_cert:
     description: "PEM-encoded CA certificate for secure, mutually authenticated TLS communication"
   loggregator.tls.cc_trafficcontroller.cert:


### PR DESCRIPTION
Set the value to the same defined in cloudcontroller_ng and syslog_drain_binder (9023)

Fix #318 