### PR TITLE
Ensure dns_health_check in TC and RLP succeed only when listening

### DIFF
--- a/jobs/loggregator_trafficcontroller/templates/dns_health_check.erb
+++ b/jobs/loggregator_trafficcontroller/templates/dns_health_check.erb
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Use the traffic controller's port
-lsof -i ':<%= p("loggregator.outgoing_dropsonde_port") %>'
+lsof -i ':<%= p("loggregator.outgoing_dropsonde_port") %>' -s TCP:LISTEN
 
 # http://www.consul.io/docs/agent/checks.html
 if [ $? -ne 0 ]; then

--- a/jobs/reverse_log_proxy/templates/dns_health_check.erb
+++ b/jobs/reverse_log_proxy/templates/dns_health_check.erb
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-lsof -i ':<%= p("reverse_log_proxy.egress.port") %>'
+lsof -i ':<%= p("reverse_log_proxy.egress.port") %>' -s TCP:LISTEN
 
 # http://www.consul.io/docs/agent/checks.html
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
This matches how Doppler is setting up it's dns_health_check. Without the extra flag, the dns_health_check will succeed if metron is on the VM and connected to Doppler's 8082 port.