### PR TITLE
Integrate gRPC Throughput Load Balancer

### DIFF
--- a/plumbing/grpc_connector_benchmark_test.go
+++ b/plumbing/grpc_connector_benchmark_test.go
@@ -1,0 +1,104 @@
+package plumbing_test
+
+import (
+	"io/ioutil"
+	"log"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/apoydence/eachers/testhelpers"
+
+	"code.cloudfoundry.org/loggregator/metricemitter/testhelper"
+	"code.cloudfoundry.org/loggregator/plumbing"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/grpclog"
+)
+
+func BenchmarkGRPCConnectorParallel(b *testing.B) {
+	log.SetOutput(ioutil.Discard)
+	grpclog.SetLogger(log.New(ioutil.Discard, "", log.LstdFlags))
+
+	spyDopplerA := newSpyDoppler()
+	spyDopplerB := newSpyDoppler()
+
+	pool := plumbing.NewPool(20, grpc.WithInsecure())
+	finder := newMockFinder()
+	finder.NextOutput.Ret0 <- plumbing.Event{
+		GRPCDopplers: []string{
+			spyDopplerA.addr.String(),
+			spyDopplerB.addr.String(),
+		},
+	}
+	metricClient := testhelper.NewMetricClient()
+	batcher := newMockMetaMetricBatcher()
+	chainer := newMockBatchCounterChainer()
+	testhelpers.AlwaysReturn(batcher.BatchCounterOutput, chainer)
+	testhelpers.AlwaysReturn(chainer.SetTagOutput, chainer)
+	connector := plumbing.NewGRPCConnector(5, pool, finder, batcher, metricClient)
+
+	time.Sleep(2 * time.Second)
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		var data [][]byte
+
+		for pb.Next() {
+			data = connector.ContainerMetrics(context.Background(), "an-app-id")
+		}
+
+		_ = data
+	})
+}
+
+type spyDoppler struct {
+	addr       net.Addr
+	grpcServer *grpc.Server
+}
+
+func newSpyDoppler() *spyDoppler {
+	lis, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		panic(err)
+	}
+
+	spy := &spyDoppler{
+		addr:       lis.Addr(),
+		grpcServer: grpc.NewServer(),
+	}
+
+	plumbing.RegisterDopplerServer(spy.grpcServer, spy)
+
+	go func() {
+		log.Println(spy.grpcServer.Serve(lis))
+	}()
+
+	return spy
+}
+
+func (m *spyDoppler) Subscribe(r *plumbing.SubscriptionRequest, s plumbing.Doppler_SubscribeServer) error {
+	<-s.Context().Done()
+	return nil
+}
+
+func (m *spyDoppler) BatchSubscribe(r *plumbing.SubscriptionRequest, s plumbing.Doppler_BatchSubscribeServer) error {
+	<-s.Context().Done()
+	return nil
+}
+
+func (m *spyDoppler) ContainerMetrics(context.Context, *plumbing.ContainerMetricsRequest) (*plumbing.ContainerMetricsResponse, error) {
+	return &plumbing.ContainerMetricsResponse{
+		Payload: [][]byte{},
+	}, nil
+}
+
+func (m *spyDoppler) RecentLogs(context.Context, *plumbing.RecentLogsRequest) (*plumbing.RecentLogsResponse, error) {
+	return &plumbing.RecentLogsResponse{
+		Payload: [][]byte{},
+	}, nil
+}
+
+func (m *spyDoppler) Stop() {
+	m.grpcServer.Stop()
+}

--- a/plumbing/pool.go
+++ b/plumbing/pool.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"math/rand"
 	"sync"
-	"sync/atomic"
 	"time"
-	"unsafe"
+
+	throughputlb "code.cloudfoundry.org/grpc-throughputlb"
 
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -18,8 +17,9 @@ type Pool struct {
 	size int
 
 	mu       sync.RWMutex
-	dopplers map[string][]unsafe.Pointer
+	dopplers map[string]clientInfo
 	dialOpts []grpc.DialOption
+	numConns int
 }
 
 type clientInfo struct {
@@ -27,110 +27,80 @@ type clientInfo struct {
 	closer io.Closer
 }
 
-func NewPool(size int, opts ...grpc.DialOption) *Pool {
+func NewPool(numConns int, opts ...grpc.DialOption) *Pool {
 	return &Pool{
-		size:     size,
-		dopplers: make(map[string][]unsafe.Pointer),
+		dopplers: make(map[string]clientInfo),
 		dialOpts: opts,
+		numConns: numConns,
 	}
 }
 
 func (p *Pool) RegisterDoppler(addr string) {
-	clients := make([]unsafe.Pointer, p.size)
-
-	p.mu.Lock()
-	p.dopplers[addr] = clients
-	p.mu.Unlock()
-
-	for i := 0; i < p.size; i++ {
-		go p.connectToDoppler(addr, clients, i)
-	}
+	go p.connectToDoppler(addr)
 }
 
 func (p *Pool) Subscribe(dopplerAddr string, ctx context.Context, req *SubscriptionRequest) (Doppler_BatchSubscribeClient, error) {
 	p.mu.RLock()
-	clients := p.dopplers[dopplerAddr]
+	ci, ok := p.dopplers[dopplerAddr]
 	p.mu.RUnlock()
 
-	client := p.fetchClient(clients)
-
-	if client == nil {
+	if !ok {
 		return nil, fmt.Errorf("no connections available for subscription")
 	}
 
-	return client.BatchSubscribe(ctx, req)
+	return ci.client.BatchSubscribe(ctx, req)
 }
 
 func (p *Pool) ContainerMetrics(dopplerAddr string, ctx context.Context, req *ContainerMetricsRequest) (*ContainerMetricsResponse, error) {
 	p.mu.RLock()
-	clients := p.dopplers[dopplerAddr]
+	ci, ok := p.dopplers[dopplerAddr]
 	p.mu.RUnlock()
 
-	client := p.fetchClient(clients)
-
-	if client == nil {
+	if !ok {
 		return nil, fmt.Errorf("no connections available for container metrics")
 	}
 
-	return client.ContainerMetrics(ctx, req)
+	return ci.client.ContainerMetrics(ctx, req)
 }
 
 func (p *Pool) RecentLogs(dopplerAddr string, ctx context.Context, req *RecentLogsRequest) (*RecentLogsResponse, error) {
 	p.mu.RLock()
-	clients := p.dopplers[dopplerAddr]
+	ci, ok := p.dopplers[dopplerAddr]
 	p.mu.RUnlock()
 
-	client := p.fetchClient(clients)
-
-	if client == nil {
+	if !ok {
 		return nil, fmt.Errorf("no connections available for recent logs")
 	}
 
-	return client.RecentLogs(ctx, req)
+	return ci.client.RecentLogs(ctx, req)
 }
 
 func (p *Pool) Close(dopplerAddr string) {
 	p.mu.Lock()
-	clients := p.dopplers[dopplerAddr]
+	ci, ok := p.dopplers[dopplerAddr]
 	delete(p.dopplers, dopplerAddr)
 	p.mu.Unlock()
 
-	for i := range clients {
-		clt := atomic.LoadPointer(&clients[i])
-		if clt == nil ||
-			(*clientInfo)(clt) == nil {
-			continue
-		}
-
-		client := *(*clientInfo)(clt)
-		client.closer.Close()
+	if ok {
+		ci.closer.Close()
 	}
 }
 
-func (p *Pool) fetchClient(clients []unsafe.Pointer) DopplerClient {
-	seed := rand.Int()
-	for i := range clients {
-		idx := (i + seed) % p.size
-		clt := atomic.LoadPointer(&clients[idx])
-		if clt == nil ||
-			(*clientInfo)(clt) == nil {
-			continue
-		}
-
-		client := *(*clientInfo)(clt)
-		return client.client
+func (p *Pool) connectToDoppler(addr string) {
+	opts := []grpc.DialOption{
+		grpc.WithBalancer(
+			throughputlb.NewThroughputLoadBalancer(100, p.numConns),
+		),
 	}
 
-	return nil
-}
+	for _, o := range p.dialOpts {
+		opts = append(opts, o)
+	}
 
-func (p *Pool) connectToDoppler(addr string, clients []unsafe.Pointer, idx int) {
 	for {
-		// TODO: Do we need this log line? It prints the same log line based
-		// on pool size
 		log.Printf("adding doppler %s", addr)
 
-		conn, err := grpc.Dial(addr, p.dialOpts...)
+		conn, err := grpc.Dial(addr, opts...)
 		if err != nil {
 			// TODO: We don't yet understand how this could happen, we should.
 			// TODO: Replace with exponential backoff.
@@ -139,13 +109,13 @@ func (p *Pool) connectToDoppler(addr string, clients []unsafe.Pointer, idx int) 
 			continue
 		}
 
-		client := NewDopplerClient(conn)
-		info := clientInfo{
-			client: client,
+		p.mu.Lock()
+		p.dopplers[addr] = clientInfo{
+			client: NewDopplerClient(conn),
 			closer: conn,
 		}
+		p.mu.Unlock()
 
-		atomic.StorePointer(&clients[idx], unsafe.Pointer(&info))
 		return
 	}
 }


### PR DESCRIPTION
The gRPC throughput load balancer will notify the gRPC dialer to open a given number of connections to a single address. Then when you either open a stream or make an RPC request the load balancer will select the connection with the least number of active requests for the new stream or request.

The order gRPC calls methods on the gRPC throughput load balancer are:
1. Start
1. Notify
1. Up
1. Get

## Benchmarks (See commit for benchmark source)

### Without gRPC Throughput LB (97c48138ac74cbf210494cdea3a5904f8234b578)

```
plumbing » go test -bench GRPCConnector -benchmem -run No                                                                     ~/w/l/s/c/l/plumbing
     | BenchmarkGRPCConnectorParallel-8            30000             44117 ns/op           12555 B/op        259 allocs/op
     | BenchmarkGRPCConnectorParallel-8            30000             41976 ns/op           12552 B/op        259 allocs/op
     | BenchmarkGRPCConnectorParallel-8            30000             42680 ns/op           12552 B/op        259 allocs/op
     | BenchmarkGRPCConnectorParallel-8            30000             42395 ns/op           12556 B/op        259 allocs/op
     | BenchmarkGRPCConnectorParallel-8            30000             40478 ns/op           12550 B/op        259 allocs/op
```

### With gRPC Throughput LB

```
plumbing [master] » go test -bench GRPCConnector -benchmem -run No                                                            ~/w/l/s/c/l/plumbing
     | BenchmarkGRPCConnectorParallel-8            30000             42348 ns/op           12620 B/op        261 allocs/op
     | BenchmarkGRPCConnectorParallel-8            30000             42657 ns/op           12621 B/op        261 allocs/op
     | BenchmarkGRPCConnectorParallel-8            30000             40908 ns/op           12621 B/op        261 allocs/op
     | BenchmarkGRPCConnectorParallel-8            30000             41828 ns/op           12621 B/op        261 allocs/op
     | BenchmarkGRPCConnectorParallel-8            30000             41398 ns/op           12621 B/op        261 allocs/op
```