### PR TITLE
Have tests bind to localhost vs all interfaces

### DIFF
--- a/agent/app/app_v1_test.go
+++ b/agent/app/app_v1_test.go
@@ -29,7 +29,7 @@ var _ = Describe("v1 App", func() {
 		)
 		Expect(err).ToNot(HaveOccurred())
 
-		config := testservers.BuildAgentConfig("localhost", 1234)
+		config := testservers.BuildAgentConfig("127.0.0.1", 1234)
 		config.Zone = "something-bad"
 		expectedHost, _, err := net.SplitHostPort(config.RouterAddrWithAZ)
 		Expect(err).ToNot(HaveOccurred())

--- a/agent/app/app_v2_test.go
+++ b/agent/app/app_v2_test.go
@@ -35,7 +35,7 @@ var _ = Describe("v2 App", func() {
 		)
 		Expect(err).ToNot(HaveOccurred())
 
-		config := testservers.BuildAgentConfig("localhost", 1234)
+		config := testservers.BuildAgentConfig("127.0.0.1", 1234)
 		config.Zone = "something-bad"
 		expectedHost, _, err := net.SplitHostPort(config.RouterAddrWithAZ)
 		Expect(err).ToNot(HaveOccurred())

--- a/agent/internal/clientpool/v1/pusher_fetcher_test.go
+++ b/agent/internal/clientpool/v1/pusher_fetcher_test.go
@@ -81,7 +81,7 @@ var _ = Describe("PusherFetcher", func() {
 
 	It("returns an error when the server is unavailable", func() {
 		fetcher := v1.NewPusherFetcher(newSpyRegistry(), grpc.WithInsecure())
-		_, _, err := fetcher.Fetch("localhost:1122")
+		_, _, err := fetcher.Fetch("127.0.0.1:1122")
 		Expect(err).To(HaveOccurred())
 	})
 })
@@ -128,7 +128,7 @@ func newSpyIngestorServer() *SpyIngestorServer {
 }
 
 func (s *SpyIngestorServer) Start() error {
-	lis, err := net.Listen("tcp", "localhost:0")
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return err
 	}

--- a/agent/internal/clientpool/v2/sender_fetcher_test.go
+++ b/agent/internal/clientpool/v2/sender_fetcher_test.go
@@ -62,7 +62,7 @@ var _ = Describe("PusherFetcher", func() {
 
 	It("returns an error when the server is unavailable", func() {
 		fetcher := v2.NewSenderFetcher(newSpyRegistry(), grpc.WithInsecure())
-		_, _, err := fetcher.Fetch("localhost:1122")
+		_, _, err := fetcher.Fetch("127.0.0.1:1122")
 		Expect(err).To(HaveOccurred())
 	})
 })
@@ -109,7 +109,7 @@ func newSpyIngestorServer() *SpyIngestorServer {
 }
 
 func (s *SpyIngestorServer) Start() error {
-	lis, err := net.Listen("tcp", "localhost:0")
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return err
 	}

--- a/integration_tests/agent/agent_test.go
+++ b/integration_tests/agent/agent_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Agent", func() {
 		Expect(err).ToNot(HaveOccurred())
 		defer consumerServer.Stop()
 		agentCleanup, agentPorts := testservers.StartAgent(
-			testservers.BuildAgentConfig("localhost", consumerServer.Port()),
+			testservers.BuildAgentConfig("127.0.0.1", consumerServer.Port()),
 		)
 		defer agentCleanup()
 
@@ -73,7 +73,7 @@ var _ = Describe("Agent", func() {
 		Expect(err).ToNot(HaveOccurred())
 		defer consumerServer.Stop()
 		agentCleanup, agentPorts := testservers.StartAgent(
-			testservers.BuildAgentConfig("localhost", consumerServer.Port()),
+			testservers.BuildAgentConfig("127.0.0.1", consumerServer.Port()),
 		)
 		defer agentCleanup()
 

--- a/integration_tests/agent/egress_test.go
+++ b/integration_tests/agent/egress_test.go
@@ -22,10 +22,10 @@ var _ = Describe("Agent", func() {
 		)
 		defer dopplerCleanup()
 		agentCleanup, agentPorts := testservers.StartAgent(
-			testservers.BuildAgentConfig("localhost", dopplerPorts.GRPC),
+			testservers.BuildAgentConfig("127.0.0.1", dopplerPorts.GRPC),
 		)
 		defer agentCleanup()
-		egressCleanup, egressClient := dopplerEgressClient(fmt.Sprintf("localhost:%d", dopplerPorts.GRPC))
+		egressCleanup, egressClient := dopplerEgressClient(fmt.Sprintf("127.0.0.1:%d", dopplerPorts.GRPC))
 		defer egressCleanup()
 
 		var subscriptionClient plumbing.Doppler_SubscribeClient
@@ -64,7 +64,7 @@ var _ = Describe("Agent", func() {
 })
 
 func sendAppLog(appID, msg string, port int) error {
-	dropsonde.Initialize(fmt.Sprintf("localhost:%d", port), "test-origin")
+	dropsonde.Initialize(fmt.Sprintf("127.0.0.1:%d", port), "test-origin")
 	return logs.SendAppLog(appID, msg, appID, "0")
 }
 

--- a/integration_tests/agent/health_endpoint_test.go
+++ b/integration_tests/agent/health_endpoint_test.go
@@ -17,11 +17,11 @@ var _ = Describe("Agent Health Endpoint", func() {
 		Expect(err).ToNot(HaveOccurred())
 		defer consumerServer.Stop()
 		agentCleanup, agentPorts := testservers.StartAgent(
-			testservers.BuildAgentConfig("localhost", consumerServer.Port()),
+			testservers.BuildAgentConfig("127.0.0.1", consumerServer.Port()),
 		)
 		defer agentCleanup()
 
-		resp, err := http.Get(fmt.Sprintf("http://localhost:%d/health", agentPorts.Health))
+		resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/health", agentPorts.Health))
 		Expect(err).ToNot(HaveOccurred())
 		defer resp.Body.Close()
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))

--- a/integration_tests/agent/mock_server_test.go
+++ b/integration_tests/agent/mock_server_test.go
@@ -35,7 +35,7 @@ func NewServer() (*Server, error) {
 	mockDopplerV1 := newMockDopplerIngestorServerV1()
 	mockDopplerV2 := newMockDopplerIngressServerV2()
 
-	lis, err := net.Listen("tcp", "localhost:0")
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return nil, err
 	}

--- a/integration_tests/endtoend/endtoend_test.go
+++ b/integration_tests/endtoend/endtoend_test.go
@@ -17,7 +17,7 @@ var _ = Describe("End to end tests", func() {
 		)
 		defer dopplerCleanup()
 		agentCleanup, agentPorts := testservers.StartAgent(
-			testservers.BuildAgentConfig("localhost", dopplerPorts.GRPC),
+			testservers.BuildAgentConfig("127.0.0.1", dopplerPorts.GRPC),
 		)
 		defer agentCleanup()
 		trafficcontrollerCleanup, tcPorts := testservers.StartTrafficController(

--- a/integration_tests/router/firehose_test.go
+++ b/integration_tests/router/firehose_test.go
@@ -21,9 +21,9 @@ var _ = Describe("Firehose test", func() {
 				testservers.BuildRouterConfig(0, 0),
 			)
 			defer dopplerCleanup()
-			ingressCleanup, ingressClient := dopplerIngressV1Client(fmt.Sprintf("localhost:%d", dopplerPorts.GRPC))
+			ingressCleanup, ingressClient := dopplerIngressV1Client(fmt.Sprintf("127.0.0.1:%d", dopplerPorts.GRPC))
 			defer ingressCleanup()
-			egressCleanup, egressClient := dopplerEgressV1Client(fmt.Sprintf("localhost:%d", dopplerPorts.GRPC))
+			egressCleanup, egressClient := dopplerEgressV1Client(fmt.Sprintf("127.0.0.1:%d", dopplerPorts.GRPC))
 			defer egressCleanup()
 
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -66,9 +66,9 @@ var _ = Describe("Firehose test", func() {
 				testservers.BuildRouterConfig(0, 0),
 			)
 			defer dopplerCleanup()
-			ingressCleanup, ingressClient := dopplerIngressV1Client(fmt.Sprintf("localhost:%d", dopplerPorts.GRPC))
+			ingressCleanup, ingressClient := dopplerIngressV1Client(fmt.Sprintf("127.0.0.1:%d", dopplerPorts.GRPC))
 			defer ingressCleanup()
-			egressCleanup, egressClient := dopplerEgressV1Client(fmt.Sprintf("localhost:%d", dopplerPorts.GRPC))
+			egressCleanup, egressClient := dopplerEgressV1Client(fmt.Sprintf("127.0.0.1:%d", dopplerPorts.GRPC))
 			defer egressCleanup()
 
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -111,9 +111,9 @@ var _ = Describe("Firehose test", func() {
 				testservers.BuildRouterConfig(0, 0),
 			)
 			defer dopplerCleanup()
-			ingressCleanup, ingressClient := dopplerIngressV1Client(fmt.Sprintf("localhost:%d", dopplerPorts.GRPC))
+			ingressCleanup, ingressClient := dopplerIngressV1Client(fmt.Sprintf("127.0.0.1:%d", dopplerPorts.GRPC))
 			defer ingressCleanup()
-			egressCleanup, egressClient := dopplerEgressV1Client(fmt.Sprintf("localhost:%d", dopplerPorts.GRPC))
+			egressCleanup, egressClient := dopplerEgressV1Client(fmt.Sprintf("127.0.0.1:%d", dopplerPorts.GRPC))
 			defer egressCleanup()
 
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -161,9 +161,9 @@ var _ = Describe("Firehose test", func() {
 				testservers.BuildRouterConfig(0, 0),
 			)
 			defer dopplerCleanup()
-			ingressCleanup, ingressClient := dopplerIngressV1Client(fmt.Sprintf("localhost:%d", dopplerPorts.GRPC))
+			ingressCleanup, ingressClient := dopplerIngressV1Client(fmt.Sprintf("127.0.0.1:%d", dopplerPorts.GRPC))
 			defer ingressCleanup()
-			egressCleanup, egressClient := dopplerEgressV1Client(fmt.Sprintf("localhost:%d", dopplerPorts.GRPC))
+			egressCleanup, egressClient := dopplerEgressV1Client(fmt.Sprintf("127.0.0.1:%d", dopplerPorts.GRPC))
 			defer egressCleanup()
 
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -207,9 +207,9 @@ var _ = Describe("Firehose test", func() {
 				testservers.BuildRouterConfig(0, 0),
 			)
 			defer dopplerCleanup()
-			ingressCleanup, ingressClient := dopplerIngressV2Client(fmt.Sprintf("localhost:%d", dopplerPorts.GRPC))
+			ingressCleanup, ingressClient := dopplerIngressV2Client(fmt.Sprintf("127.0.0.1:%d", dopplerPorts.GRPC))
 			defer ingressCleanup()
-			egressCleanup, egressClient := dopplerEgressV1Client(fmt.Sprintf("localhost:%d", dopplerPorts.GRPC))
+			egressCleanup, egressClient := dopplerEgressV1Client(fmt.Sprintf("127.0.0.1:%d", dopplerPorts.GRPC))
 			defer egressCleanup()
 
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -268,9 +268,9 @@ var _ = Describe("Firehose test", func() {
 				testservers.BuildRouterConfig(0, 0),
 			)
 			defer dopplerCleanup()
-			ingressCleanup, ingressClient := dopplerIngressV2Client(fmt.Sprintf("localhost:%d", dopplerPorts.GRPC))
+			ingressCleanup, ingressClient := dopplerIngressV2Client(fmt.Sprintf("127.0.0.1:%d", dopplerPorts.GRPC))
 			defer ingressCleanup()
-			egressCleanup, egressClient := dopplerEgressV1Client(fmt.Sprintf("localhost:%d", dopplerPorts.GRPC))
+			egressCleanup, egressClient := dopplerEgressV1Client(fmt.Sprintf("127.0.0.1:%d", dopplerPorts.GRPC))
 			defer egressCleanup()
 
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/integration_tests/router/grpc_v1_persistence_test.go
+++ b/integration_tests/router/grpc_v1_persistence_test.go
@@ -21,9 +21,9 @@ var _ = Describe("Persistence", func() {
 				testservers.BuildRouterConfig(0, 0),
 			)
 			defer dopplerCleanup()
-			ingressCleanup, ingressClient := dopplerIngressV1Client(fmt.Sprintf("localhost:%d", dopplerPorts.GRPC))
+			ingressCleanup, ingressClient := dopplerIngressV1Client(fmt.Sprintf("127.0.0.1:%d", dopplerPorts.GRPC))
 			defer ingressCleanup()
-			egressCleanup, egressClient := dopplerEgressV1Client(fmt.Sprintf("localhost:%d", dopplerPorts.GRPC))
+			egressCleanup, egressClient := dopplerEgressV1Client(fmt.Sprintf("127.0.0.1:%d", dopplerPorts.GRPC))
 			defer egressCleanup()
 
 			containerMetric := NewContainerMetric("some-test-app-id", 0, 1, 2, 3)
@@ -43,9 +43,9 @@ var _ = Describe("Persistence", func() {
 				testservers.BuildRouterConfig(0, 0),
 			)
 			defer dopplerCleanup()
-			ingressCleanup, ingressClient := dopplerIngressV1Client(fmt.Sprintf("localhost:%d", dopplerPorts.GRPC))
+			ingressCleanup, ingressClient := dopplerIngressV1Client(fmt.Sprintf("127.0.0.1:%d", dopplerPorts.GRPC))
 			defer ingressCleanup()
-			egressCleanup, egressClient := dopplerEgressV1Client(fmt.Sprintf("localhost:%d", dopplerPorts.GRPC))
+			egressCleanup, egressClient := dopplerEgressV1Client(fmt.Sprintf("127.0.0.1:%d", dopplerPorts.GRPC))
 			defer egressCleanup()
 
 			containerMetric := NewContainerMetric("some-test-app-id", 0, 100, 2, 3)
@@ -71,9 +71,9 @@ var _ = Describe("Persistence", func() {
 				testservers.BuildRouterConfig(0, 0),
 			)
 			defer dopplerCleanup()
-			ingressCleanup, ingressClient := dopplerIngressV1Client(fmt.Sprintf("localhost:%d", dopplerPorts.GRPC))
+			ingressCleanup, ingressClient := dopplerIngressV1Client(fmt.Sprintf("127.0.0.1:%d", dopplerPorts.GRPC))
 			defer ingressCleanup()
-			egressCleanup, egressClient := dopplerEgressV1Client(fmt.Sprintf("localhost:%d", dopplerPorts.GRPC))
+			egressCleanup, egressClient := dopplerEgressV1Client(fmt.Sprintf("127.0.0.1:%d", dopplerPorts.GRPC))
 			defer egressCleanup()
 
 			containerMetric := NewContainerMetric("some-test-app-id", 0, 10, 2, 3)
@@ -97,9 +97,9 @@ var _ = Describe("Persistence", func() {
 				testservers.BuildRouterConfig(0, 0),
 			)
 			defer dopplerCleanup()
-			ingressCleanup, ingressClient := dopplerIngressV1Client(fmt.Sprintf("localhost:%d", dopplerPorts.GRPC))
+			ingressCleanup, ingressClient := dopplerIngressV1Client(fmt.Sprintf("127.0.0.1:%d", dopplerPorts.GRPC))
 			defer ingressCleanup()
-			egressCleanup, egressClient := dopplerEgressV1Client(fmt.Sprintf("localhost:%d", dopplerPorts.GRPC))
+			egressCleanup, egressClient := dopplerEgressV1Client(fmt.Sprintf("127.0.0.1:%d", dopplerPorts.GRPC))
 			defer egressCleanup()
 
 			logMessage := NewLogMessage(events.LogMessage_OUT, "msg 1", "some-test-app-id", "APP")
@@ -118,9 +118,9 @@ var _ = Describe("Persistence", func() {
 				testservers.BuildRouterConfig(0, 0),
 			)
 			defer dopplerCleanup()
-			ingressCleanup, ingressClient := dopplerIngressV1Client(fmt.Sprintf("localhost:%d", dopplerPorts.GRPC))
+			ingressCleanup, ingressClient := dopplerIngressV1Client(fmt.Sprintf("127.0.0.1:%d", dopplerPorts.GRPC))
 			defer ingressCleanup()
-			egressCleanup, egressClient := dopplerEgressV1Client(fmt.Sprintf("localhost:%d", dopplerPorts.GRPC))
+			egressCleanup, egressClient := dopplerEgressV1Client(fmt.Sprintf("127.0.0.1:%d", dopplerPorts.GRPC))
 			defer egressCleanup()
 
 			logMessage0 := NewLogMessage(events.LogMessage_OUT, "msg 1", "some-test-app-id", "APP")
@@ -143,9 +143,9 @@ var _ = Describe("Persistence", func() {
 				testservers.BuildRouterConfig(0, 0),
 			)
 			defer dopplerCleanup()
-			ingressCleanup, ingressClient := dopplerIngressV1Client(fmt.Sprintf("localhost:%d", dopplerPorts.GRPC))
+			ingressCleanup, ingressClient := dopplerIngressV1Client(fmt.Sprintf("127.0.0.1:%d", dopplerPorts.GRPC))
 			defer ingressCleanup()
-			egressCleanup, egressClient := dopplerEgressV1Client(fmt.Sprintf("localhost:%d", dopplerPorts.GRPC))
+			egressCleanup, egressClient := dopplerEgressV1Client(fmt.Sprintf("127.0.0.1:%d", dopplerPorts.GRPC))
 			defer egressCleanup()
 
 			for i := 0; i < 15; i++ {

--- a/integration_tests/router/grpc_v1_streaming_log_test.go
+++ b/integration_tests/router/grpc_v1_streaming_log_test.go
@@ -20,9 +20,9 @@ var _ = Describe("GRPC Streaming Logs", func() {
 				testservers.BuildRouterConfig(0, 0),
 			)
 			defer dopplerCleanup()
-			ingressCleanup, ingressClient := dopplerIngressV1Client(fmt.Sprintf("localhost:%d", dopplerPorts.GRPC))
+			ingressCleanup, ingressClient := dopplerIngressV1Client(fmt.Sprintf("127.0.0.1:%d", dopplerPorts.GRPC))
 			defer ingressCleanup()
-			egressCleanup, egressClient := dopplerEgressV1Client(fmt.Sprintf("localhost:%d", dopplerPorts.GRPC))
+			egressCleanup, egressClient := dopplerEgressV1Client(fmt.Sprintf("127.0.0.1:%d", dopplerPorts.GRPC))
 			defer egressCleanup()
 
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/integration_tests/router/health_endpoint_test.go
+++ b/integration_tests/router/health_endpoint_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Doppler Health Endpoint", func() {
 		)
 		defer dopplerCleanup()
 
-		resp, err := http.Get(fmt.Sprintf("http://localhost:%d/health", dopplerPorts.Health))
+		resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/health", dopplerPorts.Health))
 		Expect(err).ToNot(HaveOccurred())
 		defer resp.Body.Close()
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))

--- a/integration_tests/router/v2_egress_test.go
+++ b/integration_tests/router/v2_egress_test.go
@@ -20,11 +20,11 @@ var _ = Describe("V2 Egress", func() {
 			)
 			defer dopplerCleanup()
 			ingressCleanup, ingressClient := dopplerIngressV1Client(
-				fmt.Sprintf("localhost:%d", dopplerPorts.GRPC),
+				fmt.Sprintf("127.0.0.1:%d", dopplerPorts.GRPC),
 			)
 			defer ingressCleanup()
 			egressCleanup, egressClient := dopplerEgressV2Client(
-				fmt.Sprintf("localhost:%d", dopplerPorts.GRPC),
+				fmt.Sprintf("127.0.0.1:%d", dopplerPorts.GRPC),
 			)
 			defer egressCleanup()
 
@@ -77,10 +77,10 @@ var _ = Describe("V2 Egress", func() {
 				testservers.BuildRouterConfig(0, 0),
 			)
 			ingressCleanup, ingressClient = dopplerIngressV2Client(
-				fmt.Sprintf("localhost:%d", dopplerPorts.GRPC),
+				fmt.Sprintf("127.0.0.1:%d", dopplerPorts.GRPC),
 			)
 			egressCleanup, egressClient = dopplerEgressV2Client(
-				fmt.Sprintf("localhost:%d", dopplerPorts.GRPC),
+				fmt.Sprintf("127.0.0.1:%d", dopplerPorts.GRPC),
 			)
 		})
 

--- a/integration_tests/trafficcontroller/suite_test.go
+++ b/integration_tests/trafficcontroller/suite_test.go
@@ -56,18 +56,18 @@ var _ = AfterSuite(func() {
 })
 
 var setupFakeAuthServer = func() {
-	fakeAuthServer := &FakeAuthServer{ApiEndpoint: ":42123"}
+	fakeAuthServer := &FakeAuthServer{ApiEndpoint: "localhost:42123"}
 	fakeAuthServer.Start()
 
 	Eventually(func() error {
-		_, err := http.Get("http://" + localIPAddress + ":42123")
+		_, err := http.Get("http://" + localIPAddress + "localhost:42123")
 		return err
 	}).ShouldNot(HaveOccurred())
 }
 
 var setupFakeUaaServer = func() {
 	fakeUaaServer := &FakeUaaHandler{}
-	go http.ListenAndServe(":5678", fakeUaaServer)
+	go http.ListenAndServe("localhost:5678", fakeUaaServer)
 	Eventually(func() error {
 		_, err := http.Get("http://" + localIPAddress + ":5678/check_token")
 		return err

--- a/integration_tests/trafficcontroller/suite_test.go
+++ b/integration_tests/trafficcontroller/suite_test.go
@@ -56,18 +56,18 @@ var _ = AfterSuite(func() {
 })
 
 var setupFakeAuthServer = func() {
-	fakeAuthServer := &FakeAuthServer{ApiEndpoint: "localhost:42123"}
+	fakeAuthServer := &FakeAuthServer{ApiEndpoint: "127.0.0.1:42123"}
 	fakeAuthServer.Start()
 
 	Eventually(func() error {
-		_, err := http.Get("http://" + localIPAddress + "localhost:42123")
+		_, err := http.Get("http://" + localIPAddress + "127.0.0.1:42123")
 		return err
 	}).ShouldNot(HaveOccurred())
 }
 
 var setupFakeUaaServer = func() {
 	fakeUaaServer := &FakeUaaHandler{}
-	go http.ListenAndServe("localhost:5678", fakeUaaServer)
+	go http.ListenAndServe("127.0.0.1:5678", fakeUaaServer)
 	Eventually(func() error {
 		_, err := http.Get("http://" + localIPAddress + ":5678/check_token")
 		return err

--- a/lats/helpers_test.go
+++ b/lats/helpers_test.go
@@ -95,7 +95,7 @@ func WaitForWebsocketConnection(printer *TestDebugPrinter) {
 }
 
 func EmitToMetronV1(envelope *events.Envelope) {
-	metronConn, err := net.Dial("udp4", fmt.Sprintf("localhost:%d", config.DropsondePort))
+	metronConn, err := net.Dial("udp4", fmt.Sprintf("127.0.0.1:%d", config.DropsondePort))
 	Expect(err).NotTo(HaveOccurred())
 
 	b, err := envelope.Marshal()
@@ -114,7 +114,7 @@ func EmitToMetronV2(envelope *v2.Envelope) {
 	)
 	Expect(err).NotTo(HaveOccurred())
 
-	conn, err := grpc.Dial("localhost:3458", grpc.WithTransportCredentials(creds))
+	conn, err := grpc.Dial("127.0.0.1:3458", grpc.WithTransportCredentials(creds))
 	Expect(err).NotTo(HaveOccurred())
 	defer conn.Close()
 	c := v2.NewIngressClient(conn)

--- a/lats/http_event_test.go
+++ b/lats/http_event_test.go
@@ -19,7 +19,7 @@ var _ = Describe("Sending HTTP events through loggregator", func() {
 		It("should emit an HttpStartStop through the firehose", func() {
 			msgChan, errorChan := ConnectToFirehose()
 
-			udpEmitter, err := emitter.NewUdpEmitter(fmt.Sprintf("localhost:%d", config.DropsondePort))
+			udpEmitter, err := emitter.NewUdpEmitter(fmt.Sprintf("127.0.0.1:%d", config.DropsondePort))
 			Expect(err).ToNot(HaveOccurred())
 			origin := fmt.Sprintf("%s-%d", OriginName, time.Now().UnixNano())
 			emitter := emitter.NewEventEmitter(udpEmitter, origin)
@@ -55,7 +55,7 @@ var _ = Describe("Sending HTTP events through loggregator", func() {
 			id, _ := uuid.NewV4()
 			msgChan, errorChan := ConnectToStream(id.String())
 
-			udpEmitter, err := emitter.NewUdpEmitter(fmt.Sprintf("localhost:%d", config.DropsondePort))
+			udpEmitter, err := emitter.NewUdpEmitter(fmt.Sprintf("127.0.0.1:%d", config.DropsondePort))
 			Expect(err).ToNot(HaveOccurred())
 			emitter := emitter.NewEventEmitter(udpEmitter, OriginName)
 			r, err := http.NewRequest("HEAD", "/", nil)

--- a/plumbing/grpc_connector_benchmark_test.go
+++ b/plumbing/grpc_connector_benchmark_test.go
@@ -52,7 +52,7 @@ type spyDoppler struct {
 }
 
 func newSpyDoppler() *spyDoppler {
-	lis, err := net.Listen("tcp", "localhost:0")
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		panic(err)
 	}

--- a/plumbing/grpc_connector_test.go
+++ b/plumbing/grpc_connector_test.go
@@ -39,8 +39,8 @@ var _ = Describe("GRPCConnector", func() {
 
 		pool := plumbing.NewPool(2, grpc.WithInsecure())
 
-		lisA, serverA := startGRPCServer(mockDopplerServerA, "localhost:0")
-		lisB, serverB := startGRPCServer(mockDopplerServerB, "localhost:0")
+		lisA, serverA := startGRPCServer(mockDopplerServerA, "127.0.0.1:0")
+		lisB, serverB := startGRPCServer(mockDopplerServerB, "127.0.0.1:0")
 		listeners = append(listeners, lisA, lisB)
 		grpcServers = append(grpcServers, serverA, serverB)
 
@@ -144,7 +144,7 @@ var _ = Describe("GRPCConnector", func() {
 						Eventually(mockDopplerServerB.BatchSubscribeCalled).Should(HaveLen(1))
 
 						mockDopplerServerC := newMockDopplerServer()
-						lisC, serverC := startGRPCServer(mockDopplerServerC, "localhost:0")
+						lisC, serverC := startGRPCServer(mockDopplerServerC, "127.0.0.1:0")
 						listeners = append(listeners, lisC)
 						grpcServers = append(grpcServers, serverC)
 
@@ -522,7 +522,7 @@ type MockDopplerServer struct {
 }
 
 func NewMockDopplerServer(containerMetric, recentLog []byte) *MockDopplerServer {
-	lis, err := net.Listen("tcp", "localhost:0")
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	Expect(err).ToNot(HaveOccurred())
 
 	mockServer := &MockDopplerServer{

--- a/plumbing/grpc_connector_test.go
+++ b/plumbing/grpc_connector_test.go
@@ -39,8 +39,8 @@ var _ = Describe("GRPCConnector", func() {
 
 		pool := plumbing.NewPool(2, grpc.WithInsecure())
 
-		lisA, serverA := startGRPCServer(mockDopplerServerA, ":0")
-		lisB, serverB := startGRPCServer(mockDopplerServerB, ":0")
+		lisA, serverA := startGRPCServer(mockDopplerServerA, "localhost:0")
+		lisB, serverB := startGRPCServer(mockDopplerServerB, "localhost:0")
 		listeners = append(listeners, lisA, lisB)
 		grpcServers = append(grpcServers, serverA, serverB)
 
@@ -144,7 +144,7 @@ var _ = Describe("GRPCConnector", func() {
 						Eventually(mockDopplerServerB.BatchSubscribeCalled).Should(HaveLen(1))
 
 						mockDopplerServerC := newMockDopplerServer()
-						lisC, serverC := startGRPCServer(mockDopplerServerC, ":0")
+						lisC, serverC := startGRPCServer(mockDopplerServerC, "localhost:0")
 						listeners = append(listeners, lisC)
 						grpcServers = append(grpcServers, serverC)
 

--- a/plumbing/pool_test.go
+++ b/plumbing/pool_test.go
@@ -45,8 +45,8 @@ var _ = Describe("Pool", func() {
 		)
 
 		BeforeEach(func() {
-			lis1, accepter1 = accepter(startListener(":0"))
-			lis2, accepter2 = accepter(startListener(":0"))
+			lis1, accepter1 = accepter(startListener("localhost:0"))
+			lis2, accepter2 = accepter(startListener("localhost:0"))
 			listeners = append(listeners, lis1, lis2)
 		})
 
@@ -98,7 +98,7 @@ var _ = Describe("Pool", func() {
 
 		Context("when the doppler is already available", func() {
 			BeforeEach(func() {
-				lis1, server1 = startGRPCServer(mockDoppler1, ":0")
+				lis1, server1 = startGRPCServer(mockDoppler1, "localhost:0")
 				listeners = append(listeners, lis1)
 				servers = append(servers, server1)
 
@@ -174,7 +174,7 @@ var _ = Describe("Pool", func() {
 
 		Context("when the doppler is registered", func() {
 			BeforeEach(func() {
-				lis1, server1 = startGRPCServer(mockDoppler1, ":0")
+				lis1, server1 = startGRPCServer(mockDoppler1, "localhost:0")
 				listeners = append(listeners, lis1)
 				servers = append(servers, server1)
 

--- a/plumbing/pool_test.go
+++ b/plumbing/pool_test.go
@@ -45,8 +45,8 @@ var _ = Describe("Pool", func() {
 		)
 
 		BeforeEach(func() {
-			lis1, accepter1 = accepter(startListener("localhost:0"))
-			lis2, accepter2 = accepter(startListener("localhost:0"))
+			lis1, accepter1 = accepter(startListener("127.0.0.1:0"))
+			lis2, accepter2 = accepter(startListener("127.0.0.1:0"))
 			listeners = append(listeners, lis1, lis2)
 		})
 
@@ -98,7 +98,7 @@ var _ = Describe("Pool", func() {
 
 		Context("when the doppler is already available", func() {
 			BeforeEach(func() {
-				lis1, server1 = startGRPCServer(mockDoppler1, "localhost:0")
+				lis1, server1 = startGRPCServer(mockDoppler1, "127.0.0.1:0")
 				listeners = append(listeners, lis1)
 				servers = append(servers, server1)
 
@@ -174,7 +174,7 @@ var _ = Describe("Pool", func() {
 
 		Context("when the doppler is registered", func() {
 			BeforeEach(func() {
-				lis1, server1 = startGRPCServer(mockDoppler1, "localhost:0")
+				lis1, server1 = startGRPCServer(mockDoppler1, "127.0.0.1:0")
 				listeners = append(listeners, lis1)
 				servers = append(servers, server1)
 

--- a/rlp/app/rlp_test.go
+++ b/rlp/app/rlp_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Start", func() {
 			Expect(dopplerLis.Close()).To(Succeed())
 		}()
 
-		egressAddr, _ := setupRLP(dopplerLis, "localhost:0")
+		egressAddr, _ := setupRLP(dopplerLis, "127.0.0.1:0")
 
 		egressStream, cleanup := setupRLPStream(egressAddr)
 		defer cleanup()
@@ -48,7 +48,7 @@ var _ = Describe("Start", func() {
 			Expect(dopplerLis.Close()).To(Succeed())
 		}()
 
-		egressAddr, _ := setupRLP(dopplerLis, "localhost:0")
+		egressAddr, _ := setupRLP(dopplerLis, "127.0.0.1:0")
 
 		egressStream, cleanup := setupRLPBatchedStream(egressAddr)
 		defer cleanup()
@@ -73,7 +73,7 @@ var _ = Describe("Start", func() {
 			}
 		}()
 
-		egressAddr, _ := setupRLP(dopplerLis, "localhost:0")
+		egressAddr, _ := setupRLP(dopplerLis, "127.0.0.1:0")
 		egressClient, cleanup := setupRLPQueryClient(egressAddr)
 		defer cleanup()
 
@@ -106,7 +106,7 @@ var _ = Describe("Start", func() {
 			}
 		}()
 
-		egressAddr, _ := setupRLP(dopplerLis, "localhost:0")
+		egressAddr, _ := setupRLP(dopplerLis, "127.0.0.1:0")
 		createStream := func() error {
 			egressClient, _ := setupRLPClient(egressAddr)
 			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
@@ -144,7 +144,7 @@ var _ = Describe("Start", func() {
 				}
 			}()
 
-			egressAddr, rlp := setupRLP(dopplerLis, "localhost:0")
+			egressAddr, rlp := setupRLP(dopplerLis, "127.0.0.1:0")
 
 			egressClient, cleanup := setupRLPQueryClient(egressAddr)
 			defer cleanup()
@@ -177,7 +177,7 @@ var _ = Describe("Start", func() {
 			defer func() {
 				Expect(dopplerLis.Close()).To(Succeed())
 			}()
-			egressAddr, rlp := setupRLP(dopplerLis, "localhost:0")
+			egressAddr, rlp := setupRLP(dopplerLis, "127.0.0.1:0")
 
 			stream, cleanup := setupRLPStream(egressAddr)
 			defer cleanup()
@@ -247,7 +247,7 @@ func setupDoppler() (*mockDopplerServer, *spyDopplerV2, net.Listener) {
 	dopplerV1 := newMockDopplerServer()
 	dopplerV2 := newSpyDopplerV2()
 
-	lis, err := net.Listen("tcp", "localhost:0")
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	Expect(err).ToNot(HaveOccurred())
 
 	tlsCredentials, err := plumbing.NewServerCredentials(

--- a/rlp/internal/ingress/grpc_connector_test.go
+++ b/rlp/internal/ingress/grpc_connector_test.go
@@ -158,7 +158,7 @@ type MockDopplerServer struct {
 }
 
 func startMockDopplerServer() *MockDopplerServer {
-	lis, err := net.Listen("tcp", "localhost:0")
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	Expect(err).ToNot(HaveOccurred())
 
 	mockServer := &MockDopplerServer{

--- a/rlp/internal/ingress/pool_test.go
+++ b/rlp/internal/ingress/pool_test.go
@@ -31,8 +31,8 @@ var _ = Describe("Pool", func() {
 		)
 
 		BeforeEach(func() {
-			lis1, accepter1 = accepter(startListener(":0"))
-			lis2, accepter2 = accepter(startListener(":0"))
+			lis1, accepter1 = accepter(startListener("localhost:0"))
+			lis2, accepter2 = accepter(startListener("localhost:0"))
 			listeners = append(listeners, lis1, lis2)
 		})
 

--- a/rlp/internal/ingress/pool_test.go
+++ b/rlp/internal/ingress/pool_test.go
@@ -31,8 +31,8 @@ var _ = Describe("Pool", func() {
 		)
 
 		BeforeEach(func() {
-			lis1, accepter1 = accepter(startListener("localhost:0"))
-			lis2, accepter2 = accepter(startListener("localhost:0"))
+			lis1, accepter1 = accepter(startListener("127.0.0.1:0"))
+			lis2, accepter2 = accepter(startListener("127.0.0.1:0"))
 			listeners = append(listeners, lis1, lis2)
 		})
 

--- a/router/internal/server/v1/doppler_server_test.go
+++ b/router/internal/server/v1/doppler_server_test.go
@@ -483,7 +483,7 @@ func buildLogMessage() (*events.Envelope, []byte) {
 }
 
 func startGRPCServer(ds plumbing.DopplerServer) net.Listener {
-	lis, err := net.Listen("tcp", ":0")
+	lis, err := net.Listen("tcp", "localhost:0")
 	Expect(err).ToNot(HaveOccurred())
 	s := grpc.NewServer()
 	plumbing.RegisterDopplerServer(s, ds)

--- a/router/internal/server/v1/doppler_server_test.go
+++ b/router/internal/server/v1/doppler_server_test.go
@@ -483,7 +483,7 @@ func buildLogMessage() (*events.Envelope, []byte) {
 }
 
 func startGRPCServer(ds plumbing.DopplerServer) net.Listener {
-	lis, err := net.Listen("tcp", "localhost:0")
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	Expect(err).ToNot(HaveOccurred())
 	s := grpc.NewServer()
 	plumbing.RegisterDopplerServer(s, ds)

--- a/router/internal/server/v1/ingestor_server_test.go
+++ b/router/internal/server/v1/ingestor_server_test.go
@@ -22,7 +22,7 @@ import (
 
 var _ = Describe("IngestorServer", func() {
 	var startGRPCServer = func(ds plumbing.DopplerIngestorServer) (*grpc.Server, string) {
-		lis, err := net.Listen("tcp", ":0")
+		lis, err := net.Listen("tcp", "localhost:0")
 		Expect(err).ToNot(HaveOccurred())
 		s := grpc.NewServer()
 		plumbing.RegisterDopplerIngestorServer(s, ds)

--- a/router/internal/server/v1/ingestor_server_test.go
+++ b/router/internal/server/v1/ingestor_server_test.go
@@ -22,7 +22,7 @@ import (
 
 var _ = Describe("IngestorServer", func() {
 	var startGRPCServer = func(ds plumbing.DopplerIngestorServer) (*grpc.Server, string) {
-		lis, err := net.Listen("tcp", "localhost:0")
+		lis, err := net.Listen("tcp", "127.0.0.1:0")
 		Expect(err).ToNot(HaveOccurred())
 		s := grpc.NewServer()
 		plumbing.RegisterDopplerIngestorServer(s, ds)

--- a/testservers/router.go
+++ b/testservers/router.go
@@ -20,7 +20,7 @@ func BuildRouterConfig(agentUDPPort, agentGRPCPort int) app.Config {
 			KeyFile:  Cert("doppler.key"),
 			CAFile:   Cert("loggregator-ca.crt"),
 		},
-		HealthAddr: "localhost:0",
+		HealthAddr: "127.0.0.1:0",
 
 		Agent: app.Agent{
 			UDPAddress:  fmt.Sprintf("127.0.0.1:%d", agentUDPPort),


### PR DESCRIPTION
This PR changes tests to bind to `localhost:port` vs `:port`. This allows for most of the tests to run in environments where processes can not bind to all network interfaces. The remaining tests will be fixed after I submit my PR to have all processes bind on addrs vs ports.