### PR TITLE
make slow consumer log message report which address and endpoint is slow

### DIFF
--- a/trafficcontroller/internal/proxy/websocket_server.go
+++ b/trafficcontroller/internal/proxy/websocket_server.go
@@ -79,7 +79,7 @@ func (s *WebSocketServer) ServeWS(
 				)
 				s.health.Inc("slowConsumerCount")
 
-				log.Print("Doppler Proxy: Slow Consumer")
+				log.Print("Doppler Proxy: Slow Consumer from %s using %s", r.RemoteAddr, r.URL)
 				return
 			}
 		}


### PR DESCRIPTION
it can be difficult to determine which nozzles is causing slow consumer metrics to increment in situations where there are several different nozzles feeding form the firehose.

request printing information from the client request along with the slow consumer log.