### PR TITLE
RLP gateway json error

### DIFF
--- a/rlp-gateway/internal/web/json_error.go
+++ b/rlp-gateway/internal/web/json_error.go
@@ -11,6 +11,7 @@ var (
 	errMissingType                = newJSONError("missing_envelope_type", "query must provide at least one envelope type")
 	errCounterNamePresentButEmpty = newJSONError("missing_counter_name", "counter.name is invalid without value")
 	errGaugeNamePresentButEmpty   = newJSONError("missing_gauge_name", "gauge.name is invalid without value")
+	errStreamingUnsupported       = newJSONError("streaming_unsupported", "request does not support streaming")
 )
 
 type jsonError struct {

--- a/rlp-gateway/internal/web/read.go
+++ b/rlp-gateway/internal/web/read.go
@@ -51,7 +51,7 @@ func ReadHandler(lp LogsProvider) http.HandlerFunc {
 
 		flusher, ok := w.(http.Flusher)
 		if !ok {
-			http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+			http.Error(w, errStreamingUnsupported.Error(), http.StatusInternalServerError)
 			return
 		}
 

--- a/rlp-gateway/internal/web/read_test.go
+++ b/rlp-gateway/internal/web/read_test.go
@@ -197,6 +197,20 @@ var _ = Describe("Read", func() {
 			"message": "method not allowed"
 		}`))
 	})
+
+	It("return 500, internal server error when streaming is not supported", func() {
+		req, err := http.NewRequest(http.MethodGet, server.URL+"/v2/read?log", nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		w := &nonFlusherWriter{httptest.NewRecorder()}
+		web.ReadHandler(lp)(w, req)
+
+		Expect(w.rw.Code).To(Equal(http.StatusInternalServerError))
+		Expect(w.rw.Body).To(MatchJSON(`{
+			"error": "streaming_unsupported",
+			"message": "request does not support streaming"
+		}`))
+	})
 })
 
 type stubLogsProvider struct {
@@ -223,4 +237,22 @@ func (s *stubLogsProvider) requests() []*loggregator_v2.EgressBatchRequest {
 	defer s.mu.Unlock()
 
 	return s._requests
+}
+
+// nonFlusherWriter is a wrapper around the httptest.ResponseRecorder that
+// excludes the Flush() function.
+type nonFlusherWriter struct {
+	rw *httptest.ResponseRecorder
+}
+
+func (w *nonFlusherWriter) Header() http.Header {
+	return w.rw.Header()
+}
+
+func (w *nonFlusherWriter) Write(d []byte) (int, error) {
+	return w.rw.Write(d)
+}
+
+func (w *nonFlusherWriter) WriteHeader(statusCode int) {
+	w.rw.WriteHeader(statusCode)
 }


### PR DESCRIPTION
The `streaming unsupported` error was missed when we originally converted all the error responses to JSON.